### PR TITLE
Move terminationGracePeriodSeconds to pod

### DIFF
--- a/charts/gotenberg/CHANGELOG.md
+++ b/charts/gotenberg/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.2
+
+- Fix `terminationGracePeriodSeconds` set in the wrong place. (Thanks to Szczepan Rędzioch | @redzioch)
+
 ## 0.2.1
 
 - Bump app version to `7.2.2`.

--- a/charts/gotenberg/Chart.yaml
+++ b/charts/gotenberg/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: '0.2.1'
+version: '0.2.2'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gotenberg/README.md
+++ b/charts/gotenberg/README.md
@@ -1,7 +1,7 @@
 # Gotenberg
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/gotenberg)](https://artifacthub.io/packages/search?repo=gotenberg)
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.7.2](https://img.shields.io/badge/AppVersion-7.7.2-informational?style=flat-square)
+![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.7.2](https://img.shields.io/badge/AppVersion-7.7.2-informational?style=flat-square)
 
 This is a HELM chart for Gotenberg.
 

--- a/charts/gotenberg/templates/deployment.yaml
+++ b/charts/gotenberg/templates/deployment.yaml
@@ -165,7 +165,7 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          terminationGracePeriodSeconds: {{ .Values.gotenberg.gracefulShutdownDurationSec }}
+      terminationGracePeriodSeconds: {{ .Values.gotenberg.gracefulShutdownDurationSec }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
According to current k8s spec `terminationGracePeriodSeconds` should be used with pods:
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#podspec-v1-core