### PR TITLE
Add tmp volume

### DIFF
--- a/charts/gotenberg/CHANGELOG.md
+++ b/charts/gotenberg/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0
+
+- Add `volumes` and `volumeMounts`
+
 ## 0.5.1
 
 - Bump `gotenberg` version `7.9.1` -> `7.9.2`.

--- a/charts/gotenberg/CHANGELOG.md
+++ b/charts/gotenberg/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.6.0
 
-- Add `volumes` and `volumeMounts`
+- Add `volumes` and `volumeMounts`. (Thanks to [@pschumacher](https://github.com/pschumacher))
 
 ## 0.5.1
 

--- a/charts/gotenberg/Chart.yaml
+++ b/charts/gotenberg/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.5.1"
+version: "0.6.0"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gotenberg/README.md
+++ b/charts/gotenberg/README.md
@@ -1,7 +1,7 @@
 # Gotenberg
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/gotenberg)](https://artifacthub.io/packages/search?repo=gotenberg)
-![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.9.2](https://img.shields.io/badge/AppVersion-7.9.2-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.9.2](https://img.shields.io/badge/AppVersion-7.9.2-informational?style=flat-square)
 
 This is a HELM chart for Gotenberg.
 
@@ -108,6 +108,8 @@ helm upgrade my-release maikumori/gotenberg --install
 | serviceAccount.create | bool | `false` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. # If not set and create is true, a name is generated using the fullname template |
 | tolerations | list | `[]` |  |
+| volumeMounts | list | `[]` |  |
+| volumes | list | `[]` |  |
 | webhook.allowList | string | `""` | Set the allowed URLs for the webhook feature using a regular expression |
 | webhook.clientTimeout | string | `""` | Set the time limit for requests to the webhook (default 30s) |
 | webhook.denyList | string | `""` | Set the denied URLs for the webhook feature using a regular expression |

--- a/charts/gotenberg/templates/deployment.yaml
+++ b/charts/gotenberg/templates/deployment.yaml
@@ -174,6 +174,8 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            {{- toYaml .Values.volumeMounts | nindent 12 }}
       terminationGracePeriodSeconds: {{ .Values.gotenberg.gracefulShutdownDurationSec }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -185,5 +187,9 @@ spec:
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/gotenberg/values.yaml
+++ b/charts/gotenberg/values.yaml
@@ -66,6 +66,16 @@ tolerations: []
 
 affinity: {}
 
+volumes: []
+#  - name: tmp-volume
+#    emptyDir:
+#      medium: Memory
+#      sizeLimit: 2Gi
+
+volumeMounts: []
+#  - name: tmp-volume
+#    mountPath: /tmp
+
 ingress:
   # -- Set to true to enable ingress record generation. WARNING: Gotenberg shouldn't be exposed to the internet.
   enabled: false


### PR DESCRIPTION
The Chromium module needs to be able to write to the /tmp directory of the container. When running the container with a read-only filesystem (securityContext.readOnlyRootFilesystem), this leads to the following Gotenberg error:

`create request context: create working directory: create directory /tmp/6035cd1c-8e13-4e53-a871-c4c56d3e04bc: mkdir /tmp/6035cd1c-8e13-4e53-a871-c4c56d3e04bc: read-only file system`

In oder to support running a read-only filesystem, it should be possible to configure a volume that is mounted at /tmp.

Tasks:

 - [ x ] I've made changes
 - [ x ] I've bumped chart's version in `Chart.yaml`
 - [ x ] I've added changes to charts `CHANGELOG.md`
 - [ x ] I've run [`helm-docs`](https://github.com/norwoodj/helm-docs)