### PR TITLE
Fix typo in `.Values.prometheus`

### DIFF
--- a/charts/gotenberg/CHANGELOG.md
+++ b/charts/gotenberg/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 1.0.1
 
-- Fix typo in `.Values.prometheus.namespace`.
+- Fix typo in `.Values.prometheus.namespace`. (Thanks to Szczepan Rędzioch | [@redzioch](https://github.com/redzioch))
+- Bump `gotenberg` version `8.0.1` -> `8.0.2`.
 
 ## 1.0.0
 

--- a/charts/gotenberg/CHANGELOG.md
+++ b/charts/gotenberg/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.1
+
+- Fix typo in `.Values.prometheus.namespace`.
+
 ## 1.0.0
 
 - Bump `gotenberg` version `7.10.1` -> `8.0.1`.

--- a/charts/gotenberg/Chart.yaml
+++ b/charts/gotenberg/Chart.yaml
@@ -22,7 +22,7 @@ version: "1.0.1"
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "8.0.1"
+appVersion: "8.0.2"
 
 keywords:
   - gotenberg

--- a/charts/gotenberg/Chart.yaml
+++ b/charts/gotenberg/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.0.0"
+version: "1.0.1"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gotenberg/README.md
+++ b/charts/gotenberg/README.md
@@ -1,7 +1,7 @@
 # Gotenberg
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/gotenberg)](https://artifacthub.io/packages/search?repo=gotenberg)
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.0.1](https://img.shields.io/badge/AppVersion-8.0.1-informational?style=flat-square)
+![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.0.2](https://img.shields.io/badge/AppVersion-8.0.2-informational?style=flat-square)
 
 This is a HELM chart for Gotenberg.
 

--- a/charts/gotenberg/README.md
+++ b/charts/gotenberg/README.md
@@ -102,7 +102,7 @@ helm upgrade my-release maikumori/gotenberg --install
 | prometheus.collectInterval | string | `""` | Set the interval for collecting modules' metrics (default 1s) |
 | prometheus.disableCollect | bool | `false` | Disable the collect of metrics |
 | prometheus.disableRouterLogging | bool | `false` | Disable the route logging |
-| prometheus.namespece | string | `""` | Set the namespace of modules' metrics (default "gotenberg") |
+| prometheus.namespace | string | `""` | Set the namespace of modules' metrics (default "gotenberg") |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | securityContext.privileged | bool | `false` |  |

--- a/charts/gotenberg/values.yaml
+++ b/charts/gotenberg/values.yaml
@@ -198,7 +198,7 @@ prometheus:
   # -- Set the interval for collecting modules' metrics (default 1s)
   collectInterval: ""
   # -- Set the namespace of modules' metrics (default "gotenberg")
-  namespece: ""
+  namespace: ""
   # -- Disable the collect of metrics
   disableCollect: false
   # -- Disable the route logging


### PR DESCRIPTION
I found a typo: `namespece` should be changed to `namespace` in `.Values.prometheus`.

Typo was only in `values.yaml` and therefore in `README.md`. Both fixed. In `Deployment` it was correct.

Tasks:

 - [x] I've made changes
 - [x] I've bumped chart's version in `Chart.yaml`
 - [x] I've added changes to charts `CHANGELOG.md`
 - [x] I've run [`helm-docs`](https://github.com/norwoodj/helm-docs)
