### PR TITLE
Bump `gotenberg` version `8.0.2` -> `8.1.0`.

### DIFF
--- a/charts/gotenberg/CHANGELOG.md
+++ b/charts/gotenberg/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.1.0
+
+- Bump `gotenberg` version `8.0.2` -> `8.1.0`.
+
+- Add new flags:
+
+  - `--chromium-max-queue-size`
+  - `--libreoffice-max-queue-size`
+
 ## 1.0.1
 
 - Fix typo in `.Values.prometheus.namespace`. (Thanks to Szczepan Rędzioch | [@redzioch](https://github.com/redzioch))

--- a/charts/gotenberg/Chart.yaml
+++ b/charts/gotenberg/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.0.1"
+version: "1.1.0"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "8.0.2"
+appVersion: "8.1.0"
 
 keywords:
   - gotenberg

--- a/charts/gotenberg/README.md
+++ b/charts/gotenberg/README.md
@@ -1,7 +1,7 @@
 # Gotenberg
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/gotenberg)](https://artifacthub.io/packages/search?repo=gotenberg)
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.0.2](https://img.shields.io/badge/AppVersion-8.0.2-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.0](https://img.shields.io/badge/AppVersion-8.1.0-informational?style=flat-square)
 
 This is a HELM chart for Gotenberg.
 
@@ -71,6 +71,7 @@ helm upgrade my-release maikumori/gotenberg --install
 | chromium.hostResolverRules | string | `""` | Set custom mappings to the host resolver |
 | chromium.ignoreCertificateErrors | bool | `false` | Ignore the certificate errors |
 | chromium.incognito | bool | `false` | Start Chromium with incognito mode |
+| chromium.maxQueueSize | int | `0` | Maximum request queue size for Chromium. Set to 0 to disable this feature. |
 | chromium.proxyServer | string | `""` | Set the outbound proxy server; this switch only affects HTTP and HTTPS requests |
 | chromium.restartAfter | string | `""` | Number of conversions after which Chromium will automatically restart. Set to 0 to disable this feature |
 | chromium.startTimeout | string | `""` | Maximum duration to wait for Chromium to start or restart |
@@ -87,6 +88,7 @@ helm upgrade my-release maikumori/gotenberg --install
 | ingress.tls | list | `[]` | Set the TLS configuration for the ingress, see values.yaml for an example. |
 | libreOffice.autoStart | bool | `false` | Automatically launch LibreOffce upon initialization if set to true; otherwise, LibreOffice will start at the time of the first conversion (default false) |
 | libreOffice.disableRoutes | bool | `false` | Disable the routes |
+| libreOffice.maxQueueSize | int | `0` | Maximum request queue size for LibreOffice. Set to 0 to disable this feature. |
 | libreOffice.restartAfter | string | `""` | Number of conversions after which LibreOffice will automatically restart. Set to 0 to disable this feature (default 10) |
 | libreOffice.startTimeout | string | `""` | Maximum duration to wait for LibreOffice to start or restart (default 10s) |
 | logging.fieldsPrefix | string | `""` | Prepend a specified prefix to each field in the logs |

--- a/charts/gotenberg/templates/deployment.yaml
+++ b/charts/gotenberg/templates/deployment.yaml
@@ -100,6 +100,9 @@ spec:
           {{- if .Values.chromium.clearCookies }}
           - --chromium-clear-cookies
           {{- end }}
+          {{- if .Values.chromium.maxQueueSize }}
+          - --chromium-max-queue-size={{ .Values.chromium.maxQueueSize }}
+          {{- end }}
 
           {{- if .Values.libreOffice.restartAfter }}
           - --libreoffice-restart-after={{ .Values.libreOffice.restartAfter }}
@@ -112,6 +115,9 @@ spec:
           {{- end }}
           {{- if .Values.libreOffice.disableRoutes }}
           - --libreoffice-disable-routes
+          {{- end }}
+          {{- if .Values.libreOffice.maxQueueSize }}
+          - --libreoffice-max-queue-size={{ .Values.libreOffice.maxQueueSize }}
           {{- end }}
 
           {{- if .Values.pdfEngines.engines }}

--- a/charts/gotenberg/values.yaml
+++ b/charts/gotenberg/values.yaml
@@ -148,6 +148,8 @@ chromium:
   clearCache: false
   # -- Clear Chromium cookies between each conversion.
   clearCookies: false
+  # -- Maximum request queue size for Chromium. Set to 0 to disable this feature.
+  maxQueueSize: 0
 
 # The LibreOffice module interacts with LibreOffice to convert documents to PDF, thanks to unoconv.
 # https://gotenberg.dev/docs/modules/libreoffice
@@ -160,6 +162,8 @@ libreOffice:
   startTimeout: ""
   # -- Disable the routes
   disableRoutes: false
+  # -- Maximum request queue size for LibreOffice. Set to 0 to disable this feature.
+  maxQueueSize: 0
 
 # The PDF Engines module gathers all engines that can manipulate PDF files.
 # https://gotenberg.dev/docs/modules/pdf-engines


### PR DESCRIPTION
Add new flags:
 - `--chromium-max-queue-size`
 - `--libreoffice-max-queue-size`

Tasks:

 - [x] I've made changes
 - [x] I've bumped chart's version in `Chart.yaml`
 - [x] I've added changes to charts `CHANGELOG.md`
 - [x] I've run [`helm-docs`](https://github.com/norwoodj/helm-docs)
