### PR TITLE
Add `securityContext` compatibility with OpenShift platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+.vscode
+.DS_Store

--- a/charts/gotenberg/CHANGELOG.md
+++ b/charts/gotenberg/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.0
+
+- Add `securityContext` compatibility with OpenShift platform. (Thanks to Jonas Geiler | [@jonasgeiler](https://github.com/jonasgeiler))
+
 ## 1.2.0
 
 - Bump `gotenberg` version `8.1.0` -> `8.5.0`.

--- a/charts/gotenberg/Chart.yaml
+++ b/charts/gotenberg/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.2.0"
+version: "1.3.0"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gotenberg/README.md
+++ b/charts/gotenberg/README.md
@@ -1,7 +1,7 @@
 # Gotenberg
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/gotenberg)](https://artifacthub.io/packages/helm/maikumori/gotenberg)
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.5.0](https://img.shields.io/badge/AppVersion-8.5.0-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.5.0](https://img.shields.io/badge/AppVersion-8.5.0-informational?style=flat-square)
 
 This is a HELM chart for Gotenberg.
 
@@ -78,6 +78,7 @@ helm upgrade my-release maikumori/gotenberg --install
 | chromium.proxyServer | string | `""` | Set the outbound proxy server; this switch only affects HTTP and HTTPS requests |
 | chromium.restartAfter | string | `""` | Number of conversions after which Chromium will automatically restart. Set to 0 to disable this feature |
 | chromium.startTimeout | string | `""` | Maximum duration to wait for Chromium to start or restart |
+| compatibility.openshift.adaptSecurityContext | string | `"auto"` | Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: auto (apply if the detected running cluster is Openshift), force (perform the adaptation always), disabled (do not perform adaptation) |
 | fullnameOverride | string | `""` |  |
 | gotenberg.gracefulShutdownDurationSec | int | `30` | Set the graceful shutdown duration (default 30s) |
 | image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/gotenberg/templates/_helpers.tpl
+++ b/charts/gotenberg/templates/_helpers.tpl
@@ -60,3 +60,35 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Return true if the detected platform is Openshift
+Usage:
+{{- include "gotenberg.compatibility.isOpenshift" . -}}
+*/}}
+{{- define "gotenberg.compatibility.isOpenshift" -}}
+{{- if .Capabilities.APIVersions.Has "security.openshift.io/v1" -}}
+{{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Render a compatible securityContext depending on the platform. By default it is maintained as it is. In other platforms like Openshift we remove default user/group values that do not work out of the box with the restricted-v1 SCC
+Usage:
+{{- include "gotenberg.compatibility.renderSecurityContext" (dict "secContext" .Values.containerSecurityContext "context" $) -}}
+*/}}
+{{- define "gotenberg.compatibility.renderSecurityContext" -}}
+{{- $adaptedContext := .secContext -}}
+
+{{- if (((.context.Values).compatibility).openshift) -}}
+  {{- if or (eq .context.Values.compatibility.openshift.adaptSecurityContext "force") (and (eq .context.Values.compatibility.openshift.adaptSecurityContext "auto") (include "gotenberg.compatibility.isOpenshift" .context)) -}}
+    {{/* Remove incompatible user/group values that do not work in Openshift out of the box */}}
+    {{- $adaptedContext = omit $adaptedContext "fsGroup" "runAsUser" "runAsGroup" -}}
+    {{- if not .secContext.seLinuxOptions -}}
+    {{/* If it is an empty object, we remove it from the resulting context because it causes validation issues */}}
+    {{- $adaptedContext = omit $adaptedContext "seLinuxOptions" -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- omit $adaptedContext "enabled" | toYaml -}}
+{{- end -}}

--- a/charts/gotenberg/templates/deployment.yaml
+++ b/charts/gotenberg/templates/deployment.yaml
@@ -28,12 +28,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "gotenberg.serviceAccountName" . }}
-      securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      securityContext: {{- include "gotenberg.compatibility.renderSecurityContext" (dict "secContext" .Values.podSecurityContext "context" $) | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+          securityContext: {{- include "gotenberg.compatibility.renderSecurityContext" (dict "secContext" .Values.securityContext "context" $) | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:

--- a/charts/gotenberg/values.yaml
+++ b/charts/gotenberg/values.yaml
@@ -229,3 +229,11 @@ logging:
 gotenberg:
   # -- Set the graceful shutdown duration (default 30s)
   gracefulShutdownDurationSec: 30
+
+# Compatibility adaptations for Kubernetes platforms
+compatibility:
+  # Compatibility adaptations for Openshift
+  openshift:
+    # -- Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs.
+    # Possible values: auto (apply if the detected running cluster is Openshift), force (perform the adaptation always), disabled (do not perform adaptation)
+    adaptSecurityContext: auto


### PR DESCRIPTION
This pull request makes the Gotenberg helm chart compatible with the OpenShift platform, which unfortunately requires specific securityContext settings to work. I adapted these changes from the bitnami helm chart repo where they include this OpenShift compatibility in all of their helm charts (see [here](https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_compatibility.tpl) and [here](https://github.com/bitnami/charts/blob/bf9a6535fabdd4c0ad3210920cdd6c4963c5511c/bitnami/nginx/templates/deployment.yaml#L83)). Basically I added a little helper which removes things like `runAsUser`, `runAsGroup` and `fsGroup` from the security context. I also added another helper which detects if the helm chart is being installed on an OpenShift cluster, which is used to automatically apply these compatibility changes. You can also force or disable this OpenShift detection using the new `compatibility.openshift.adaptSecurityContext` value.

Let me know if you have any further questions! We have tested this helm chart on our OpenShift cluster and it should not break anything for existing deployments.

Tasks:

 - [X] I've made changes
 - [X] I've bumped chart's version in `Chart.yaml`
 - [X] I've added changes to charts `CHANGELOG.md`
 - [X] I've run [`helm-docs`](https://github.com/norwoodj/helm-docs)
