### PR TITLE
Bump gotenberg from `8.5.1` to `8.7.0` & add HTTPS (TLS) support

### DIFF
--- a/charts/gotenberg/CHANGELOG.md
+++ b/charts/gotenberg/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.5.0
 
 - Bump `gotenberg` version `8.5.1` -> `8.6.0`.
-- Add values for the following flags:
+- Add values for the following flags (Thanks to Jonas Geiler | [@jonasgeiler](https://github.com/jonasgeiler)):
 
   - `--api-tls-cert-file`
   - `--api-tls-key-file`

--- a/charts/gotenberg/CHANGELOG.md
+++ b/charts/gotenberg/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.5.0
 
-- Bump `gotenberg` version `8.5.1` -> `8.6.0`.
+- Bump `gotenberg` version `8.5.1` -> `8.7.0`.
 - Add values for the following flags (Thanks to Jonas Geiler | [@jonasgeiler](https://github.com/jonasgeiler)):
 
   - `--api-tls-cert-file`

--- a/charts/gotenberg/CHANGELOG.md
+++ b/charts/gotenberg/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.5.0
+
+- Bump `gotenberg` version `8.5.1` -> `8.6.0`.
+- Add values for the following flags:
+
+  - `--api-tls-cert-file`
+  - `--api-tls-key-file`
+
 ## 1.4.0
 
 - Add ability to create and configure `PodDisruptionBudget` (Thanks to Aurel Canciu | [@relu](https://github.com/relu))

--- a/charts/gotenberg/CHANGELOG.md
+++ b/charts/gotenberg/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.5.0
 
 - Bump `gotenberg` version `8.5.1` -> `8.7.0`.
-- Add values for the following flags (Thanks to Jonas Geiler | [@jonasgeiler](https://github.com/jonasgeiler)):
+- Add support for the following flags (Thanks to Jonas Geiler | [@jonasgeiler](https://github.com/jonasgeiler)):
 
   - `--api-tls-cert-file`
   - `--api-tls-key-file`

--- a/charts/gotenberg/Chart.yaml
+++ b/charts/gotenberg/Chart.yaml
@@ -22,7 +22,7 @@ version: "1.5.0"
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "8.6.0"
+appVersion: "8.7.0"
 
 keywords:
   - gotenberg

--- a/charts/gotenberg/Chart.yaml
+++ b/charts/gotenberg/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.4.0"
+version: "1.5.0"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "8.5.1"
+appVersion: "8.6.0"
 
 keywords:
   - gotenberg

--- a/charts/gotenberg/README.md
+++ b/charts/gotenberg/README.md
@@ -56,8 +56,7 @@ helm upgrade my-release maikumori/gotenberg --install
 | api.port | int | `3000` | Set the port on which the API should listen (default 3000) |
 | api.rootPath | string | `""` | Set the root path of the API - for service discovery via URL paths (default "/") |
 | api.timeout | string | `""` | Set the time limit for requests (default 30s) |
-| api.tlsCertFile | string | `""` | Path to the TLS/SSL certificate file - for HTTPS support (default "") |
-| api.tlsKeyFile | string | `""` | Path to the TLS/SSL key file - for HTTPS support (default "") |
+| api.tlsSecretName | string | `""` | Enables TLS on the API server: K8S TLS secret name containing the TLS certificate and key (tls.crt, tls.key) |
 | api.traceHeader | string | `""` | Set the header name to use for identifying requests (default "Gotenberg-Trace") |
 | autoscaling.enabled | bool | `false` |  |
 | autoscaling.maxReplicas | int | `100` |  |

--- a/charts/gotenberg/README.md
+++ b/charts/gotenberg/README.md
@@ -1,7 +1,7 @@
 # Gotenberg
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/gotenberg)](https://artifacthub.io/packages/helm/maikumori/gotenberg)
-![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.6.0](https://img.shields.io/badge/AppVersion-8.6.0-informational?style=flat-square)
+![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.7.0](https://img.shields.io/badge/AppVersion-8.7.0-informational?style=flat-square)
 
 This is a HELM chart for Gotenberg.
 

--- a/charts/gotenberg/README.md
+++ b/charts/gotenberg/README.md
@@ -1,7 +1,7 @@
 # Gotenberg
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/gotenberg)](https://artifacthub.io/packages/helm/maikumori/gotenberg)
-![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.5.1](https://img.shields.io/badge/AppVersion-8.5.1-informational?style=flat-square)
+![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.6.0](https://img.shields.io/badge/AppVersion-8.6.0-informational?style=flat-square)
 
 This is a HELM chart for Gotenberg.
 
@@ -56,6 +56,8 @@ helm upgrade my-release maikumori/gotenberg --install
 | api.port | int | `3000` | Set the port on which the API should listen (default 3000) |
 | api.rootPath | string | `""` | Set the root path of the API - for service discovery via URL paths (default "/") |
 | api.timeout | string | `""` | Set the time limit for requests (default 30s) |
+| api.tlsCertFile | string | `""` | Path to the TLS/SSL certificate file - for HTTPS support (default "") |
+| api.tlsKeyFile | string | `""` | Path to the TLS/SSL key file - for HTTPS support (default "") |
 | api.traceHeader | string | `""` | Set the header name to use for identifying requests (default "Gotenberg-Trace") |
 | autoscaling.enabled | bool | `false` |  |
 | autoscaling.maxReplicas | int | `100` |  |

--- a/charts/gotenberg/templates/deployment.yaml
+++ b/charts/gotenberg/templates/deployment.yaml
@@ -44,11 +44,11 @@ spec:
           args:
           - gotenberg
           - --api-port={{ .Values.api.port }}
-          {{- if .Values.api.tlsCertFile }}
-          - --api-tls-cert-file={{ .Values.api.tlsCertFile }}
+          {{- if .Values.api.tlsSecretName }}
+          - --api-tls-cert-file=/tls/tls.crt
           {{- end }}
-          {{- if .Values.api.tlsKeyFile }}
-          - --api-tls-key-file={{ .Values.api.tlsKeyFile }}
+          {{- if .Values.api.tlsSecretName }}
+          - --api-tls-key-file=/tls/tls.key
           {{- end }}
           {{- if .Values.api.timeout }}
           - --api-timeout={{ .Values.api.timeout }}
@@ -218,6 +218,11 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             {{- toYaml .Values.volumeMounts | nindent 12 }}
+            {{- if .Values.api.tlsSecretName }}
+            - name: tls
+              mountPath: /tls
+              readOnly: true
+            {{- end }}
       terminationGracePeriodSeconds: {{ .Values.gotenberg.gracefulShutdownDurationSec }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -238,4 +243,9 @@ spec:
       {{- with .Values.volumes }}
       volumes:
         {{- toYaml . | nindent 8 }}
+        {{- if .Values.api.tlsSecretName }}
+        - name: tls
+          secret:
+            secretName: {{ .Values.api.tlsSecretName }}
+        {{- end }}
       {{- end }}

--- a/charts/gotenberg/templates/deployment.yaml
+++ b/charts/gotenberg/templates/deployment.yaml
@@ -44,6 +44,12 @@ spec:
           args:
           - gotenberg
           - --api-port={{ .Values.api.port }}
+          {{- if .Values.api.tlsCertFile }}
+          - --api-tls-cert-file={{ .Values.api.tlsCertFile }}
+          {{- end }}
+          {{- if .Values.api.tlsKeyFile }}
+          - --api-tls-key-file={{ .Values.api.tlsKeyFile }}
+          {{- end }}
           {{- if .Values.api.timeout }}
           - --api-timeout={{ .Values.api.timeout }}
           {{- end }}

--- a/charts/gotenberg/values.yaml
+++ b/charts/gotenberg/values.yaml
@@ -122,6 +122,10 @@ ingress:
 api:
   # -- Set the port on which the API should listen (default 3000)
   port: 3000
+  # -- Path to the TLS/SSL certificate file - for HTTPS support (default "")
+  tlsCertFile: ""
+  # -- Path to the TLS/SSL key file - for HTTPS support (default "")
+  tlsKeyFile: ""
   # -- Set the time limit for requests (default 30s)
   timeout: ""
   # -- Set the root path of the API - for service discovery via URL paths (default "/")

--- a/charts/gotenberg/values.yaml
+++ b/charts/gotenberg/values.yaml
@@ -122,10 +122,8 @@ ingress:
 api:
   # -- Set the port on which the API should listen (default 3000)
   port: 3000
-  # -- Path to the TLS/SSL certificate file - for HTTPS support (default "")
-  tlsCertFile: ""
-  # -- Path to the TLS/SSL key file - for HTTPS support (default "")
-  tlsKeyFile: ""
+  # -- Enables TLS on the API server: K8S TLS secret name containing the TLS certificate and key (tls.crt, tls.key)
+  tlsSecretName: ""
   # -- Set the time limit for requests (default 30s)
   timeout: ""
   # -- Set the root path of the API - for service discovery via URL paths (default "/")


### PR DESCRIPTION
This PR bumps the `gotenberg` version from `8.5.1` to `8.6.0`, which adds HTTPS (TLS) support so I added the new flags to the helm chart.

https://github.com/gotenberg/gotenberg/releases/tag/v8.6.0

Tasks:

 - [X] I've made changes
 - [X] I've bumped chart's version in `Chart.yaml`
 - [X] I've added changes to charts `CHANGELOG.md`
 - [X] I've run [`helm-docs`](https://github.com/norwoodj/helm-docs)
