### PR TITLE
Add extraEnv to values

### DIFF
--- a/charts/gotenberg/CHANGELOG.md
+++ b/charts/gotenberg/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.6.0
 
+- Bump `gotenberg` version `8.8.1` -> `8.9.0`.
 - Add support for `extraEnv` annotations to provide extra environment variables to `gotenberg` container.
 
 ## 1.5.1

--- a/charts/gotenberg/CHANGELOG.md
+++ b/charts/gotenberg/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.6.0
+
+- Add support for `extraEnv` annotations to provide extra environment variables to `gotenberg` container.
+
 ## 1.5.1
 
 - Bump `gotenberg` version `8.7.0` -> `8.8.1`.

--- a/charts/gotenberg/Chart.yaml
+++ b/charts/gotenberg/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.5.1"
+version: "1.6.0"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gotenberg/Chart.yaml
+++ b/charts/gotenberg/Chart.yaml
@@ -22,7 +22,7 @@ version: "1.6.0"
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "8.8.1"
+appVersion: "8.9.0"
 
 keywords:
   - gotenberg

--- a/charts/gotenberg/README.md
+++ b/charts/gotenberg/README.md
@@ -1,7 +1,7 @@
 # Gotenberg
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/gotenberg)](https://artifacthub.io/packages/helm/maikumori/gotenberg)
-![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.8.1](https://img.shields.io/badge/AppVersion-8.8.1-informational?style=flat-square)
+![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.9.0](https://img.shields.io/badge/AppVersion-8.9.0-informational?style=flat-square)
 
 This is a HELM chart for Gotenberg.
 

--- a/charts/gotenberg/README.md
+++ b/charts/gotenberg/README.md
@@ -1,7 +1,7 @@
 # Gotenberg
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/gotenberg)](https://artifacthub.io/packages/helm/maikumori/gotenberg)
-![Version: 1.5.1](https://img.shields.io/badge/Version-1.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.8.1](https://img.shields.io/badge/AppVersion-8.8.1-informational?style=flat-square)
+![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.8.1](https://img.shields.io/badge/AppVersion-8.8.1-informational?style=flat-square)
 
 This is a HELM chart for Gotenberg.
 
@@ -79,7 +79,7 @@ helm upgrade my-release maikumori/gotenberg --install
 | chromium.proxyServer | string | `""` | Set the outbound proxy server; this switch only affects HTTP and HTTPS requests |
 | chromium.restartAfter | string | `""` | Number of conversions after which Chromium will automatically restart. Set to 0 to disable this feature |
 | chromium.startTimeout | string | `""` | Maximum duration to wait for Chromium to start or restart |
-| extraEnv | list | `[]` |  |
+| extraEnv | list | `[]` | List of extra environment variables for gotenberg container |
 | fullnameOverride | string | `""` |  |
 | gotenberg.gracefulShutdownDurationSec | int | `30` | Set the graceful shutdown duration (default 30s) |
 | image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/gotenberg/README.md
+++ b/charts/gotenberg/README.md
@@ -79,6 +79,7 @@ helm upgrade my-release maikumori/gotenberg --install
 | chromium.proxyServer | string | `""` | Set the outbound proxy server; this switch only affects HTTP and HTTPS requests |
 | chromium.restartAfter | string | `""` | Number of conversions after which Chromium will automatically restart. Set to 0 to disable this feature |
 | chromium.startTimeout | string | `""` | Maximum duration to wait for Chromium to start or restart |
+| extraEnv | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | gotenberg.gracefulShutdownDurationSec | int | `30` | Set the graceful shutdown duration (default 30s) |
 | image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/gotenberg/templates/deployment.yaml
+++ b/charts/gotenberg/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          securityContext: 
+          securityContext:
             {{- include "gotenberg.securityContext" . | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -88,7 +88,7 @@ spec:
           - --chromium-deny-list={{ .Values.chromium.denyList }}
           {{- end }}
           {{- if .Values.chromium.ignoreCertificateErrors }}
-          - --chromium-ignore-certificate-errors 
+          - --chromium-ignore-certificate-errors
           {{- end }}
           {{- if .Values.chromium.disableWebSecurity }}
           - --chromium-disable-web-security
@@ -201,6 +201,9 @@ spec:
               value: {{ .Values.api.basicAuthUsername }}
             - name: GOTENBERG_API_BASIC_AUTH_PASSWORD
               value: {{ .Values.api.basicAuthPassword }}
+          {{- end }}
+          {{- with .Values.extraEnv }}
+          {{- toYaml . | nindent 10 }}
           {{- end }}
           ports:
             - name: http

--- a/charts/gotenberg/values.yaml
+++ b/charts/gotenberg/values.yaml
@@ -94,6 +94,7 @@ volumeMounts: []
 #  - name: tmp-volume
 #    mountPath: /tmp
 
+# -- List of extra environment variables for gotenberg container
 extraEnv: []
 #  - name: FOO
 #    value: bar

--- a/charts/gotenberg/values.yaml
+++ b/charts/gotenberg/values.yaml
@@ -94,6 +94,10 @@ volumeMounts: []
 #  - name: tmp-volume
 #    mountPath: /tmp
 
+extraEnv: []
+#  - name: FOO
+#    value: bar
+
 ingress:
   # -- Set to true to enable ingress record generation. WARNING: Gotenberg shouldn't be exposed to the internet.
   enabled: false


### PR DESCRIPTION
Hello :wave:

Thanks for your work on this Helm chart! We're using it and we'd like to inject extra environment variables, here is a small contribution to be able to do that adding `extraEnv` in the values.

Let me know if there's anything you'd prefer in another way.

Paul

## Tasks:

 - [X] I've made changes
 - [X] I've bumped chart's version in `Chart.yaml`
 - [X] I've added changes to charts `CHANGELOG.md`
 - [X] I've run [`helm-docs`](https://github.com/norwoodj/helm-docs)
