### PR TITLE
Added ServiceMonitor

### DIFF
--- a/charts/gotenberg/CHANGELOG.md
+++ b/charts/gotenberg/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.7.0
+
+- Add ability to create `ServiceMonitor`
+
 ## 1.6.0
 
 - Bump `gotenberg` version `8.8.1` -> `8.9.0`.

--- a/charts/gotenberg/Chart.yaml
+++ b/charts/gotenberg/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.6.0"
+version: "1.7.0"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gotenberg/README.md
+++ b/charts/gotenberg/README.md
@@ -1,7 +1,7 @@
 # Gotenberg
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/gotenberg)](https://artifacthub.io/packages/helm/maikumori/gotenberg)
-![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.9.0](https://img.shields.io/badge/AppVersion-8.9.0-informational?style=flat-square)
+![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.9.0](https://img.shields.io/badge/AppVersion-8.9.0-informational?style=flat-square)
 
 This is a HELM chart for Gotenberg.
 
@@ -99,6 +99,16 @@ helm upgrade my-release maikumori/gotenberg --install
 | logging.fieldsPrefix | string | `""` | Prepend a specified prefix to each field in the logs |
 | logging.format | string | `""` | Set log format - auto, json, or text (default "auto") |
 | logging.level | string | `""` | Set the log level - error, warn, info, or debug (default "info") |
+| metrics.serviceMonitor.annotations | object | `{}` | Additional annotations for the service monitor |
+| metrics.serviceMonitor.enabled | bool | `false` | Enable ServiceMonitor |
+| metrics.serviceMonitor.honorLabels | bool | `false` | HonorLabels chooses the metric’s labels on collisions with target labels |
+| metrics.serviceMonitor.interval | string | `nil` | Interval at which metrics should be scraped |
+| metrics.serviceMonitor.jobLabel | string | `nil` | Optional job label for the target service in Prometheus |
+| metrics.serviceMonitor.labels | object | `{}` | Additional labels for the service monitor |
+| metrics.serviceMonitor.metricRelabelings | list | `[]` | List of metric relabel configs to apply to samples before ingestion |
+| metrics.serviceMonitor.namespace | string | `nil` | Namespace for ServiceMonitor, defaults to release namespace |
+| metrics.serviceMonitor.relabelings | list | `[]` | List of relabel configs to apply to samples before scraping |
+| metrics.serviceMonitor.scrapeTimeout | string | `nil` | Timeout after which the scrape is ended |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | pdb.create | bool | `false` |  |

--- a/charts/gotenberg/templates/servicemonitor.yaml
+++ b/charts/gotenberg/templates/servicemonitor.yaml
@@ -1,0 +1,45 @@
+{{- if and (not .Values.prometheus.disableCollect) .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "gotenberg.fullname" . }}
+  namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace }}
+  labels:
+    {{- include "gotenberg.labels" . | nindent 4 }}
+{{- with .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- with .Values.metrics.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+spec:
+  {{- with .Values.metrics.serviceMonitor.jobLabel }}
+  jobLabel: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "gotenberg.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - path: /prometheus/metrics
+      port: http
+      scheme: http
+      {{- with .Values.metrics.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.honorLabels }}
+      honorLabels: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.relabelings }}
+      relabelings: {{- toYaml . | nindent 6 }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/charts/gotenberg/values.yaml
+++ b/charts/gotenberg/values.yaml
@@ -254,3 +254,26 @@ logging:
 gotenberg:
   # -- Set the graceful shutdown duration (default 30s)
   gracefulShutdownDurationSec: 30
+
+metrics:
+  serviceMonitor:
+    # -- Enable ServiceMonitor
+    enabled: false
+    # -- (string) Namespace for ServiceMonitor, defaults to release namespace
+    namespace:
+    # -- (string) Optional job label for the target service in Prometheus
+    jobLabel:
+    # -- (string) Interval at which metrics should be scraped
+    interval:
+    # -- (string) Timeout after which the scrape is ended
+    scrapeTimeout:
+    # -- HonorLabels chooses the metric’s labels on collisions with target labels
+    honorLabels: false
+    # -- List of metric relabel configs to apply to samples before ingestion
+    metricRelabelings: []
+    # -- List of relabel configs to apply to samples before scraping
+    relabelings: []
+    # -- Additional annotations for the service monitor
+    annotations: {}
+    # -- Additional labels for the service monitor
+    labels: {}


### PR DESCRIPTION
Added ability to create [ServiceMonitor](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.ServiceMonitor) for metrics scrapping.

Also, I believe it would be nice to deprecate `prometheus` key in `values.yaml` and move everything under `metrics` key.  
Let me know whether to implement this change in this PR.

Tasks:

 - [x] I've made changes
 - [x] I've bumped chart's version in `Chart.yaml`
 - [x] I've added changes to charts `CHANGELOG.md`
 - [x] I've run [`helm-docs`](https://github.com/norwoodj/helm-docs)
