### PR TITLE
Add helm schema, signing and supporting actions (version 1.8.0)

### DIFF
--- a/.cr.yaml
+++ b/.cr.yaml
@@ -1,0 +1,3 @@
+sign: true
+# UID of the GPG key to use
+key: helm@maikumori.com

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,8 @@ _Descriptive description goes here._
 
 Tasks:
 
- - [ ] I've made changes
- - [ ] I've bumped chart's version in `Chart.yaml`
- - [ ] I've added changes to charts `CHANGELOG.md`
- - [ ] I've run [`helm-docs`](https://github.com/norwoodj/helm-docs)
+- [ ] I've made changes
+- [ ] I've bumped chart's version in `Chart.yaml`
+- [ ] I've added changes to charts `CHANGELOG.md`
+- [ ] I've run [`helm-docs`](https://github.com/norwoodj/helm-docs)
+- [ ] I've run ['helm-tool schema > values.schema.json'](https://github.com/cert-manager/helm-tool)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,4 +6,4 @@ Tasks:
 - [ ] I've bumped chart's version in `Chart.yaml`
 - [ ] I've added changes to charts `CHANGELOG.md`
 - [ ] I've run [`helm-docs`](https://github.com/norwoodj/helm-docs)
-- [ ] I've run ['helm-tool schema > values.schema.json'](https://github.com/cert-manager/helm-tool)
+- [ ] I've run ['helm-tool schema | jq . > values.schema.json'](https://github.com/cert-manager/helm-tool)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,23 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v4
 
+      - name: Prepare keys for signing
+        env:
+          SIGNING_KEY_BASE64: ${{ secrets.HELM_SIGNING_PRIVATE_KEY }}
+          SIGNING_KEY_PASSPHRASE_BASE64: ${{ secrets.HELM_SIGNING_PRIVATE_KEY_PASSPHRASE }}
+          KEY_PATH: ".gpg-dir"
+          SIGNING_KEY_PATH: ".gpg-dir/secring.gpg"
+          SIGNING_KEY_PASSPHRASE_PATH: ".gpg-dir/passphrase"
+        run: |
+          mkdir "$KEY_PATH"
+          base64 -d <<< "$SIGNING_KEY_BASE64" > "$SIGNING_KEY_PATH"
+          base64 -d <<< "$SIGNING_KEY_PASSPHRASE_BASE64" > "$SIGNING_KEY_PASSPHRASE_PATH"
+          echo "CR_PASSPHRASE_FILE=$SIGNING_KEY_PASSPHRASE_PATH" >> "$GITHUB_ENV"
+          echo "CR_KEYRING=$SIGNING_KEY_PATH" >> "$GITHUB_ENV"
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        with:
+          config: .cr.yaml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,33 +3,13 @@ name: Lint and Test Charts
 on: pull_request
 
 jobs:
-  lint-test:
+  helm-tools:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        k8s:
-          - v1.28.0@sha256:b7a4cad12c197af3ba43202d3efe03246b3f0793f162afb40a33c923952d5b31
-          - v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
-          - v1.26.6@sha256:6e2d8b28a5b601defe327b98bd1c2d1930b49e5d8c512e1895099e4504007adb
-          - v1.25.11@sha256:227fa11ce74ea76a0474eeefb84cb75d8dad1b08638371ecf0e86259b35be0c8
-          - v1.24.15@sha256:7db4f8bea3e14b82d12e044e25e34bd53754b7f2b0e9d56df21774e6f66a70ab
-          - v1.23.17@sha256:59c989ff8a517a93127d4a536e7014d28e235fb3529d9fba91b3951d461edfdb
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Set up Helm
-        uses: azure/setup-helm@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-          check-latest: true
-
-      - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.6.1
 
       - uses: actions/setup-go@v5
         with:
@@ -52,6 +32,39 @@ jobs:
           fi
           popd
 
+  lint-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        k8s:
+          - kindest/node:v1.31.0@sha256:53df588e04085fd41ae12de0c3fe4c72f7013bba32a20e7325357a1ac94ba865
+          - kindest/node:v1.30.4@sha256:976ea815844d5fa93be213437e3ff5754cd599b040946b5cca43ca45c2047114
+          - kindest/node:v1.30.3@sha256:bf91e1ef2f7d92bb7734b2b896b3dddea98f0496b34d96e37dd5d7df331b7e56
+          - kindest/node:v1.29.8@sha256:d46b7aa29567e93b27f7531d258c372e829d7224b25e3fc6ffdefed12476d3aa
+          - kindest/node:v1.29.7@sha256:f70ab5d833fca132a100c1f95490be25d76188b053f49a3c0047ff8812360baf
+          - kindest/node:v1.28.13@sha256:45d319897776e11167e4698f6b14938eb4d52eb381d9e3d7a9086c16c69a8110
+          - kindest/node:v1.28.12@sha256:fa0e48b1e83bb8688a5724aa7eebffbd6337abd7909ad089a2700bf08c30c6ea
+          - kindest/node:v1.27.17@sha256:3fd82731af34efe19cd54ea5c25e882985bafa2c9baefe14f8deab1737d9fabe
+          - kindest/node:v1.26.15@sha256:1cc15d7b1edd2126ef051e359bf864f37bbcf1568e61be4d2ed1df7a3e87b354
+          - kindest/node:v1.25.16@sha256:6110314339b3b44d10da7d27881849a87e092124afab5956f2e10ecdb463b025
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          check-latest: true
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.6.1
+
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
@@ -68,6 +81,7 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         uses: helm/kind-action@v1.10.0
         with:
+          version: v0.24.0
           node_image: kindest/node:${{ matrix.k8s }}
 
       - name: Run chart-testing (install)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,12 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "stable"
+          # We don't have go.sum file, but if this file changes we might as well download new dependencies.
+          cache-dependency-path: .github/workflows/test.yml
 
       - name: Install helm-tools
         run: |
-          go install github.com/cert-manager/helm-tool@latest
+          go install github.com/cert-manager/helm-tool@v0.5.3
 
       - name: Run helm-tools
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,16 +37,16 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - kindest/node:v1.31.0@sha256:53df588e04085fd41ae12de0c3fe4c72f7013bba32a20e7325357a1ac94ba865
-          - kindest/node:v1.30.4@sha256:976ea815844d5fa93be213437e3ff5754cd599b040946b5cca43ca45c2047114
-          - kindest/node:v1.30.3@sha256:bf91e1ef2f7d92bb7734b2b896b3dddea98f0496b34d96e37dd5d7df331b7e56
-          - kindest/node:v1.29.8@sha256:d46b7aa29567e93b27f7531d258c372e829d7224b25e3fc6ffdefed12476d3aa
-          - kindest/node:v1.29.7@sha256:f70ab5d833fca132a100c1f95490be25d76188b053f49a3c0047ff8812360baf
-          - kindest/node:v1.28.13@sha256:45d319897776e11167e4698f6b14938eb4d52eb381d9e3d7a9086c16c69a8110
-          - kindest/node:v1.28.12@sha256:fa0e48b1e83bb8688a5724aa7eebffbd6337abd7909ad089a2700bf08c30c6ea
-          - kindest/node:v1.27.17@sha256:3fd82731af34efe19cd54ea5c25e882985bafa2c9baefe14f8deab1737d9fabe
-          - kindest/node:v1.26.15@sha256:1cc15d7b1edd2126ef051e359bf864f37bbcf1568e61be4d2ed1df7a3e87b354
-          - kindest/node:v1.25.16@sha256:6110314339b3b44d10da7d27881849a87e092124afab5956f2e10ecdb463b025
+          - v1.31.0@sha256:53df588e04085fd41ae12de0c3fe4c72f7013bba32a20e7325357a1ac94ba865
+          - v1.30.4@sha256:976ea815844d5fa93be213437e3ff5754cd599b040946b5cca43ca45c2047114
+          - v1.30.3@sha256:bf91e1ef2f7d92bb7734b2b896b3dddea98f0496b34d96e37dd5d7df331b7e56
+          - v1.29.8@sha256:d46b7aa29567e93b27f7531d258c372e829d7224b25e3fc6ffdefed12476d3aa
+          - v1.29.7@sha256:f70ab5d833fca132a100c1f95490be25d76188b053f49a3c0047ff8812360baf
+          - v1.28.13@sha256:45d319897776e11167e4698f6b14938eb4d52eb381d9e3d7a9086c16c69a8110
+          - v1.28.12@sha256:fa0e48b1e83bb8688a5724aa7eebffbd6337abd7909ad089a2700bf08c30c6ea
+          - v1.27.17@sha256:3fd82731af34efe19cd54ea5c25e882985bafa2c9baefe14f8deab1737d9fabe
+          - v1.26.15@sha256:1cc15d7b1edd2126ef051e359bf864f37bbcf1568e61be4d2ed1df7a3e87b354
+          - v1.25.16@sha256:6110314339b3b44d10da7d27881849a87e092124afab5956f2e10ecdb463b025
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           pushd charts/gotenberg  
           helm-tool lint
-          helm-tool schema > generated-schema.json
+          helm-tool schema | jq . > generated-schema.json
           CURRENT_SCHEMA=$(cat values.schema.json)
           GENERATED_SCHEMA=$(cat generated-schema.json)
           if [ "$CURRENT_SCHEMA" != "$GENERATED_SCHEMA" ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,27 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.6.1
 
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "stable"
+
+      - name: Install helm-tools
+        run: |
+          go install github.com/cert-manager/helm-tool@latest
+
+      - name: Run helm-tools
+        run: |
+          pushd charts/gotenberg  
+          helm-tool lint
+          helm-tool schema > generated-schema.json
+          CURRENT_SCHEMA=$(cat values.schema.json)
+          GENERATED_SCHEMA=$(cat generated-schema.json)
+          if [ "$CURRENT_SCHEMA" != "$GENERATED_SCHEMA" ]; then
+            echo "Outdated schema, regenerate it with 'helm-tool schema > values.schema.json'"
+            exit 1
+          fi
+          popd
+
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |

--- a/charts/gotenberg/CHANGELOG.md
+++ b/charts/gotenberg/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Bump `gotenberg` version `8.9.11` -> `8.12.0`.
 - Add Helm schema file.
 - Update K8S to test against recent K8S versions.
+- Add chart signing to CI.
 
 ## 1.7.0
 

--- a/charts/gotenberg/CHANGELOG.md
+++ b/charts/gotenberg/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.8.0
+
+- Bump `gotenberg` version `8.9.11` -> `8.12.0`.
+- Add Helm schema file.
+- Update K8S to test against recent K8S versions.
+
 ## 1.7.0
 
 - Add ability to customize HorizontalPodAutoscaler behavior (Thanks to Anthony | [@anthosz](https://github.com/anthosz))

--- a/charts/gotenberg/Chart.yaml
+++ b/charts/gotenberg/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.7.0"
+version: "1.8.0"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "8.11.0"
+appVersion: "8.12.0"
 
 keywords:
   - gotenberg

--- a/charts/gotenberg/README.md
+++ b/charts/gotenberg/README.md
@@ -1,7 +1,7 @@
 # Gotenberg
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/gotenberg)](https://artifacthub.io/packages/helm/maikumori/gotenberg)
-![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.11.0](https://img.shields.io/badge/AppVersion-8.11.0-informational?style=flat-square)
+![Version: 1.8.0](https://img.shields.io/badge/Version-1.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.12.0](https://img.shields.io/badge/AppVersion-8.12.0-informational?style=flat-square)
 
 This is a HELM chart for Gotenberg.
 

--- a/charts/gotenberg/values.schema.json
+++ b/charts/gotenberg/values.schema.json
@@ -1,0 +1,758 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/$defs/helm-values",
+  "$defs": {
+    "helm-values": {
+      "type": "object",
+      "properties": {
+        "affinity": { "$ref": "#/$defs/helm-values.affinity" },
+        "api": { "$ref": "#/$defs/helm-values.api" },
+        "autoscaling": { "$ref": "#/$defs/helm-values.autoscaling" },
+        "chromium": { "$ref": "#/$defs/helm-values.chromium" },
+        "extraEnv": { "$ref": "#/$defs/helm-values.extraEnv" },
+        "fullnameOverride": { "$ref": "#/$defs/helm-values.fullnameOverride" },
+        "global": { "$ref": "#/$defs/helm-values.global" },
+        "gotenberg": { "$ref": "#/$defs/helm-values.gotenberg" },
+        "image": { "$ref": "#/$defs/helm-values.image" },
+        "imagePullSecrets": { "$ref": "#/$defs/helm-values.imagePullSecrets" },
+        "ingress": { "$ref": "#/$defs/helm-values.ingress" },
+        "libreOffice": { "$ref": "#/$defs/helm-values.libreOffice" },
+        "logging": { "$ref": "#/$defs/helm-values.logging" },
+        "metrics": { "$ref": "#/$defs/helm-values.metrics" },
+        "nameOverride": { "$ref": "#/$defs/helm-values.nameOverride" },
+        "nodeSelector": { "$ref": "#/$defs/helm-values.nodeSelector" },
+        "pdb": { "$ref": "#/$defs/helm-values.pdb" },
+        "pdfEngines": { "$ref": "#/$defs/helm-values.pdfEngines" },
+        "podAnnotations": { "$ref": "#/$defs/helm-values.podAnnotations" },
+        "podLabels": { "$ref": "#/$defs/helm-values.podLabels" },
+        "podSecurityContext": {
+          "$ref": "#/$defs/helm-values.podSecurityContext"
+        },
+        "progressDeadlineSeconds": {
+          "$ref": "#/$defs/helm-values.progressDeadlineSeconds"
+        },
+        "prometheus": { "$ref": "#/$defs/helm-values.prometheus" },
+        "replicaCount": { "$ref": "#/$defs/helm-values.replicaCount" },
+        "resources": { "$ref": "#/$defs/helm-values.resources" },
+        "securityContext": { "$ref": "#/$defs/helm-values.securityContext" },
+        "service": { "$ref": "#/$defs/helm-values.service" },
+        "serviceAccount": { "$ref": "#/$defs/helm-values.serviceAccount" },
+        "strategy": { "$ref": "#/$defs/helm-values.strategy" },
+        "tolerations": { "$ref": "#/$defs/helm-values.tolerations" },
+        "topologySpreadConstraints": {
+          "$ref": "#/$defs/helm-values.topologySpreadConstraints"
+        },
+        "volumeMounts": { "$ref": "#/$defs/helm-values.volumeMounts" },
+        "volumes": { "$ref": "#/$defs/helm-values.volumes" },
+        "webhook": { "$ref": "#/$defs/helm-values.webhook" }
+      },
+      "additionalProperties": false
+    },
+    "helm-values.affinity": { "type": "object", "default": {} },
+    "helm-values.api": {
+      "type": "object",
+      "properties": {
+        "basicAuthPassword": {
+          "$ref": "#/$defs/helm-values.api.basicAuthPassword"
+        },
+        "basicAuthUsername": {
+          "$ref": "#/$defs/helm-values.api.basicAuthUsername"
+        },
+        "disableDownloadFrom": {
+          "$ref": "#/$defs/helm-values.api.disableDownloadFrom"
+        },
+        "disableHealthCheckLogging": {
+          "$ref": "#/$defs/helm-values.api.disableHealthCheckLogging"
+        },
+        "downloadFromAllowList": {
+          "$ref": "#/$defs/helm-values.api.downloadFromAllowList"
+        },
+        "downloadFromDenyList": {
+          "$ref": "#/$defs/helm-values.api.downloadFromDenyList"
+        },
+        "downloadFromMaxRetry": {
+          "$ref": "#/$defs/helm-values.api.downloadFromMaxRetry"
+        },
+        "enableBasicAuth": {
+          "$ref": "#/$defs/helm-values.api.enableBasicAuth"
+        },
+        "port": { "$ref": "#/$defs/helm-values.api.port" },
+        "rootPath": { "$ref": "#/$defs/helm-values.api.rootPath" },
+        "timeout": { "$ref": "#/$defs/helm-values.api.timeout" },
+        "tlsSecretName": { "$ref": "#/$defs/helm-values.api.tlsSecretName" },
+        "traceHeader": { "$ref": "#/$defs/helm-values.api.traceHeader" }
+      },
+      "additionalProperties": false
+    },
+    "helm-values.api.basicAuthPassword": {
+      "description": "-- Set the basic authentication password"
+    },
+    "helm-values.api.basicAuthUsername": {
+      "description": "-- Set the basic authentication username"
+    },
+    "helm-values.api.disableDownloadFrom": {
+      "description": "-- Disable the download from feature",
+      "type": "boolean",
+      "default": false
+    },
+    "helm-values.api.disableHealthCheckLogging": {
+      "description": "-- Disable health check logging",
+      "type": "boolean",
+      "default": false
+    },
+    "helm-values.api.downloadFromAllowList": {
+      "description": "-- Set the allowed URLs for the download from feature using a regular expression",
+      "type": "string",
+      "default": ""
+    },
+    "helm-values.api.downloadFromDenyList": {
+      "description": "-- Set the denied URLs for the download from feature using a regular expression",
+      "type": "string",
+      "default": ""
+    },
+    "helm-values.api.downloadFromMaxRetry": {
+      "description": "-- Set the maximum number of retries for the download from feature (default 4)",
+      "type": "number",
+      "default": 4
+    },
+    "helm-values.api.enableBasicAuth": {
+      "description": "-- Enable basic authentication, see also the basicAuthUsername and basicAuthPassword values",
+      "type": "boolean",
+      "default": false
+    },
+    "helm-values.api.port": {
+      "description": "-- Set the port on which the API should listen (default 3000)",
+      "type": "number",
+      "default": 3000
+    },
+    "helm-values.api.rootPath": {
+      "description": "-- Set the root path of the API - for service discovery via URL paths (default \"/\")",
+      "type": "string",
+      "default": ""
+    },
+    "helm-values.api.timeout": {
+      "description": "-- Set the time limit for requests (default 30s)",
+      "type": "string",
+      "default": ""
+    },
+    "helm-values.api.tlsSecretName": {
+      "description": "-- Enables TLS on the API server: K8S TLS secret name containing the TLS certificate and key (tls.crt, tls.key)",
+      "type": "string",
+      "default": ""
+    },
+    "helm-values.api.traceHeader": {
+      "description": "-- Set the header name to use for identifying requests (default \"Gotenberg-Trace\")",
+      "type": "string",
+      "default": ""
+    },
+    "helm-values.autoscaling": {
+      "type": "object",
+      "properties": {
+        "behavior": { "$ref": "#/$defs/helm-values.autoscaling.behavior" },
+        "enabled": { "$ref": "#/$defs/helm-values.autoscaling.enabled" },
+        "maxReplicas": {
+          "$ref": "#/$defs/helm-values.autoscaling.maxReplicas"
+        },
+        "minReplicas": {
+          "$ref": "#/$defs/helm-values.autoscaling.minReplicas"
+        },
+        "targetCPUUtilizationPercentage": {
+          "$ref": "#/$defs/helm-values.autoscaling.targetCPUUtilizationPercentage"
+        },
+        "targetMemoryUtilizationPercentage": {
+          "$ref": "#/$defs/helm-values.autoscaling.targetMemoryUtilizationPercentage"
+        }
+      },
+      "additionalProperties": false
+    },
+    "helm-values.autoscaling.behavior": { "type": "object", "default": {} },
+    "helm-values.autoscaling.enabled": { "type": "boolean", "default": false },
+    "helm-values.autoscaling.maxReplicas": { "type": "number", "default": 100 },
+    "helm-values.autoscaling.minReplicas": { "type": "number", "default": 1 },
+    "helm-values.autoscaling.targetCPUUtilizationPercentage": {
+      "type": "number",
+      "default": 80
+    },
+    "helm-values.autoscaling.targetMemoryUtilizationPercentage": {},
+    "helm-values.chromium": {
+      "type": "object",
+      "properties": {
+        "allowFileAccessFromFiles": {
+          "$ref": "#/$defs/helm-values.chromium.allowFileAccessFromFiles"
+        },
+        "allowInsecureLocalhost": {
+          "$ref": "#/$defs/helm-values.chromium.allowInsecureLocalhost"
+        },
+        "allowList": { "$ref": "#/$defs/helm-values.chromium.allowList" },
+        "autoStart": { "$ref": "#/$defs/helm-values.chromium.autoStart" },
+        "clearCache": { "$ref": "#/$defs/helm-values.chromium.clearCache" },
+        "clearCookies": { "$ref": "#/$defs/helm-values.chromium.clearCookies" },
+        "denyList": { "$ref": "#/$defs/helm-values.chromium.denyList" },
+        "disableJavaScript": {
+          "$ref": "#/$defs/helm-values.chromium.disableJavaScript"
+        },
+        "disableRoutes": {
+          "$ref": "#/$defs/helm-values.chromium.disableRoutes"
+        },
+        "disableWebSecurity": {
+          "$ref": "#/$defs/helm-values.chromium.disableWebSecurity"
+        },
+        "hostResolverRules": {
+          "$ref": "#/$defs/helm-values.chromium.hostResolverRules"
+        },
+        "ignoreCertificateErrors": {
+          "$ref": "#/$defs/helm-values.chromium.ignoreCertificateErrors"
+        },
+        "incognito": { "$ref": "#/$defs/helm-values.chromium.incognito" },
+        "maxQueueSize": { "$ref": "#/$defs/helm-values.chromium.maxQueueSize" },
+        "proxyServer": { "$ref": "#/$defs/helm-values.chromium.proxyServer" },
+        "restartAfter": { "$ref": "#/$defs/helm-values.chromium.restartAfter" },
+        "startTimeout": { "$ref": "#/$defs/helm-values.chromium.startTimeout" }
+      },
+      "additionalProperties": false
+    },
+    "helm-values.chromium.allowFileAccessFromFiles": {
+      "description": "-- Allow file:// URIs to read other file:// URIs",
+      "type": "boolean",
+      "default": false
+    },
+    "helm-values.chromium.allowInsecureLocalhost": {
+      "description": "-- Ignore TLS/SSL errors on localhost",
+      "type": "boolean",
+      "default": false
+    },
+    "helm-values.chromium.allowList": {
+      "description": "-- Set the allowed URLs for Chromium using a regular expression",
+      "type": "string",
+      "default": ""
+    },
+    "helm-values.chromium.autoStart": {
+      "description": "-- Automatically launch Chromium upon initialization if set to true; otherwise, Chromium will start at the time of the first conversion",
+      "type": "boolean",
+      "default": false
+    },
+    "helm-values.chromium.clearCache": {
+      "description": "-- Clear Chromium cache between each conversion.",
+      "type": "boolean",
+      "default": false
+    },
+    "helm-values.chromium.clearCookies": {
+      "description": "-- Clear Chromium cookies between each conversion.",
+      "type": "boolean",
+      "default": false
+    },
+    "helm-values.chromium.denyList": {
+      "description": "-- Set the denied URLs for Chromium using a regular expression (default \"^file:///[^tmp].*\")",
+      "type": "string",
+      "default": ""
+    },
+    "helm-values.chromium.disableJavaScript": {
+      "description": "-- Disable JavaScript",
+      "type": "boolean",
+      "default": false
+    },
+    "helm-values.chromium.disableRoutes": {
+      "description": "-- Disable the routes",
+      "type": "boolean",
+      "default": false
+    },
+    "helm-values.chromium.disableWebSecurity": {
+      "description": "-- Don't enforce the same-origin policy",
+      "type": "boolean",
+      "default": false
+    },
+    "helm-values.chromium.hostResolverRules": {
+      "description": "-- Set custom mappings to the host resolver",
+      "type": "string",
+      "default": ""
+    },
+    "helm-values.chromium.ignoreCertificateErrors": {
+      "description": "-- Ignore the certificate errors",
+      "type": "boolean",
+      "default": false
+    },
+    "helm-values.chromium.incognito": {
+      "description": "-- Start Chromium with incognito mode",
+      "type": "boolean",
+      "default": false
+    },
+    "helm-values.chromium.maxQueueSize": {
+      "description": "-- Maximum request queue size for Chromium. Set to 0 to disable this feature.",
+      "type": "number",
+      "default": 0
+    },
+    "helm-values.chromium.proxyServer": {
+      "description": "-- Set the outbound proxy server; this switch only affects HTTP and HTTPS requests",
+      "type": "string",
+      "default": ""
+    },
+    "helm-values.chromium.restartAfter": {
+      "description": "-- Number of conversions after which Chromium will automatically restart. Set to 0 to disable this feature",
+      "type": "string",
+      "default": ""
+    },
+    "helm-values.chromium.startTimeout": {
+      "description": "-- Maximum duration to wait for Chromium to start or restart",
+      "type": "string",
+      "default": ""
+    },
+    "helm-values.extraEnv": {
+      "description": "-- List of extra environment variables for gotenberg container",
+      "type": "array",
+      "default": [],
+      "items": {}
+    },
+    "helm-values.fullnameOverride": { "type": "string", "default": "" },
+    "helm-values.global": {
+      "description": "Global values shared across all (sub)charts"
+    },
+    "helm-values.gotenberg": {
+      "type": "object",
+      "properties": {
+        "gracefulShutdownDurationSec": {
+          "$ref": "#/$defs/helm-values.gotenberg.gracefulShutdownDurationSec"
+        }
+      },
+      "additionalProperties": false
+    },
+    "helm-values.gotenberg.gracefulShutdownDurationSec": {
+      "description": "-- Set the graceful shutdown duration (default 30s)",
+      "type": "number",
+      "default": 30
+    },
+    "helm-values.image": {
+      "type": "object",
+      "properties": {
+        "pullPolicy": { "$ref": "#/$defs/helm-values.image.pullPolicy" },
+        "repository": { "$ref": "#/$defs/helm-values.image.repository" },
+        "tag": { "$ref": "#/$defs/helm-values.image.tag" }
+      },
+      "additionalProperties": false
+    },
+    "helm-values.image.pullPolicy": {
+      "type": "string",
+      "default": "IfNotPresent"
+    },
+    "helm-values.image.repository": {
+      "type": "string",
+      "default": "gotenberg/gotenberg"
+    },
+    "helm-values.image.tag": {
+      "description": "-- Overrides the image tag whose default is the chart appVersion.",
+      "type": "string",
+      "default": ""
+    },
+    "helm-values.imagePullSecrets": {
+      "type": "array",
+      "default": [],
+      "items": {}
+    },
+    "helm-values.ingress": {
+      "type": "object",
+      "properties": {
+        "annotations": { "$ref": "#/$defs/helm-values.ingress.annotations" },
+        "className": { "$ref": "#/$defs/helm-values.ingress.className" },
+        "enabled": { "$ref": "#/$defs/helm-values.ingress.enabled" },
+        "hosts": { "$ref": "#/$defs/helm-values.ingress.hosts" },
+        "tls": { "$ref": "#/$defs/helm-values.ingress.tls" }
+      },
+      "additionalProperties": false
+    },
+    "helm-values.ingress.annotations": {
+      "description": "-- Set the annotations of the ingress",
+      "type": "object",
+      "default": {}
+    },
+    "helm-values.ingress.className": {
+      "description": "-- Set the class name of the ingress",
+      "type": "string",
+      "default": ""
+    },
+    "helm-values.ingress.enabled": {
+      "description": "-- Set to true to enable ingress record generation. WARNING: Gotenberg shouldn't be exposed to the internet.",
+      "type": "boolean",
+      "default": false
+    },
+    "helm-values.ingress.hosts": {
+      "description": "kubernetes.io/ingress.class: nginx\nkubernetes.io/tls-acme: \"true\"\n-- Set the hostnames of the ingress, see values.yaml for an example.",
+      "type": "array",
+      "default": [],
+      "items": {}
+    },
+    "helm-values.ingress.tls": {
+      "description": "- host: chart-example.local\npaths:\n  - path: /\n    pathType: ImplementationSpecific\n-- Set the TLS configuration for the ingress, see values.yaml for an example.",
+      "type": "array",
+      "default": [],
+      "items": {}
+    },
+    "helm-values.libreOffice": {
+      "type": "object",
+      "properties": {
+        "autoStart": { "$ref": "#/$defs/helm-values.libreOffice.autoStart" },
+        "disableRoutes": {
+          "$ref": "#/$defs/helm-values.libreOffice.disableRoutes"
+        },
+        "maxQueueSize": {
+          "$ref": "#/$defs/helm-values.libreOffice.maxQueueSize"
+        },
+        "restartAfter": {
+          "$ref": "#/$defs/helm-values.libreOffice.restartAfter"
+        },
+        "startTimeout": {
+          "$ref": "#/$defs/helm-values.libreOffice.startTimeout"
+        }
+      },
+      "additionalProperties": false
+    },
+    "helm-values.libreOffice.autoStart": {
+      "description": "-- Automatically launch LibreOffce upon initialization if set to true; otherwise, LibreOffice will start at the time of the first conversion (default false)",
+      "type": "boolean",
+      "default": false
+    },
+    "helm-values.libreOffice.disableRoutes": {
+      "description": "-- Disable the routes",
+      "type": "boolean",
+      "default": false
+    },
+    "helm-values.libreOffice.maxQueueSize": {
+      "description": "-- Maximum request queue size for LibreOffice. Set to 0 to disable this feature.",
+      "type": "number",
+      "default": 0
+    },
+    "helm-values.libreOffice.restartAfter": {
+      "description": "-- Number of conversions after which LibreOffice will automatically restart. Set to 0 to disable this feature (default 10)",
+      "type": "string",
+      "default": ""
+    },
+    "helm-values.libreOffice.startTimeout": {
+      "description": "-- Maximum duration to wait for LibreOffice to start or restart (default 10s)",
+      "type": "string",
+      "default": ""
+    },
+    "helm-values.logging": {
+      "type": "object",
+      "properties": {
+        "fieldsPrefix": { "$ref": "#/$defs/helm-values.logging.fieldsPrefix" },
+        "format": { "$ref": "#/$defs/helm-values.logging.format" },
+        "level": { "$ref": "#/$defs/helm-values.logging.level" }
+      },
+      "additionalProperties": false
+    },
+    "helm-values.logging.fieldsPrefix": {
+      "description": "-- Prepend a specified prefix to each field in the logs",
+      "type": "string",
+      "default": ""
+    },
+    "helm-values.logging.format": {
+      "description": "-- Set log format - auto, json, or text (default \"auto\")",
+      "type": "string",
+      "default": ""
+    },
+    "helm-values.logging.level": {
+      "description": "-- Set the log level - error, warn, info, or debug (default \"info\")",
+      "type": "string",
+      "default": ""
+    },
+    "helm-values.metrics": {
+      "type": "object",
+      "properties": {
+        "serviceMonitor": {
+          "$ref": "#/$defs/helm-values.metrics.serviceMonitor"
+        }
+      },
+      "additionalProperties": false
+    },
+    "helm-values.metrics.serviceMonitor": {
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "$ref": "#/$defs/helm-values.metrics.serviceMonitor.annotations"
+        },
+        "enabled": {
+          "$ref": "#/$defs/helm-values.metrics.serviceMonitor.enabled"
+        },
+        "honorLabels": {
+          "$ref": "#/$defs/helm-values.metrics.serviceMonitor.honorLabels"
+        },
+        "interval": {
+          "$ref": "#/$defs/helm-values.metrics.serviceMonitor.interval"
+        },
+        "jobLabel": {
+          "$ref": "#/$defs/helm-values.metrics.serviceMonitor.jobLabel"
+        },
+        "labels": {
+          "$ref": "#/$defs/helm-values.metrics.serviceMonitor.labels"
+        },
+        "metricRelabelings": {
+          "$ref": "#/$defs/helm-values.metrics.serviceMonitor.metricRelabelings"
+        },
+        "namespace": {
+          "$ref": "#/$defs/helm-values.metrics.serviceMonitor.namespace"
+        },
+        "relabelings": {
+          "$ref": "#/$defs/helm-values.metrics.serviceMonitor.relabelings"
+        },
+        "scrapeTimeout": {
+          "$ref": "#/$defs/helm-values.metrics.serviceMonitor.scrapeTimeout"
+        }
+      },
+      "additionalProperties": false
+    },
+    "helm-values.metrics.serviceMonitor.annotations": {
+      "description": "-- Additional annotations for the service monitor",
+      "type": "object",
+      "default": {}
+    },
+    "helm-values.metrics.serviceMonitor.enabled": {
+      "description": "-- Enable ServiceMonitor",
+      "type": "boolean",
+      "default": false
+    },
+    "helm-values.metrics.serviceMonitor.honorLabels": {
+      "description": "-- HonorLabels chooses the metric’s labels on collisions with target labels",
+      "type": "boolean",
+      "default": false
+    },
+    "helm-values.metrics.serviceMonitor.interval": {
+      "description": "-- (string) Interval at which metrics should be scraped"
+    },
+    "helm-values.metrics.serviceMonitor.jobLabel": {
+      "description": "-- (string) Optional job label for the target service in Prometheus"
+    },
+    "helm-values.metrics.serviceMonitor.labels": {
+      "description": "-- Additional labels for the service monitor",
+      "type": "object",
+      "default": {}
+    },
+    "helm-values.metrics.serviceMonitor.metricRelabelings": {
+      "description": "-- List of metric relabel configs to apply to samples before ingestion",
+      "type": "array",
+      "default": [],
+      "items": {}
+    },
+    "helm-values.metrics.serviceMonitor.namespace": {
+      "description": "-- (string) Namespace for ServiceMonitor, defaults to release namespace"
+    },
+    "helm-values.metrics.serviceMonitor.relabelings": {
+      "description": "-- List of relabel configs to apply to samples before scraping",
+      "type": "array",
+      "default": [],
+      "items": {}
+    },
+    "helm-values.metrics.serviceMonitor.scrapeTimeout": {
+      "description": "-- (string) Timeout after which the scrape is ended"
+    },
+    "helm-values.nameOverride": { "type": "string", "default": "" },
+    "helm-values.nodeSelector": { "type": "object", "default": {} },
+    "helm-values.pdb": {
+      "type": "object",
+      "properties": {
+        "create": { "$ref": "#/$defs/helm-values.pdb.create" },
+        "maxUnavailable": { "$ref": "#/$defs/helm-values.pdb.maxUnavailable" },
+        "minAvailable": { "$ref": "#/$defs/helm-values.pdb.minAvailable" },
+        "unhealthyPodEvictionPolicy": {
+          "$ref": "#/$defs/helm-values.pdb.unhealthyPodEvictionPolicy"
+        }
+      },
+      "additionalProperties": false
+    },
+    "helm-values.pdb.create": { "type": "boolean", "default": false },
+    "helm-values.pdb.maxUnavailable": { "type": "string", "default": "" },
+    "helm-values.pdb.minAvailable": { "type": "number", "default": 1 },
+    "helm-values.pdb.unhealthyPodEvictionPolicy": {
+      "description": "-- This is a beta feature, so it's not enabled by default."
+    },
+    "helm-values.pdfEngines": {
+      "type": "object",
+      "properties": {
+        "disableRoutes": {
+          "$ref": "#/$defs/helm-values.pdfEngines.disableRoutes"
+        },
+        "engines": { "$ref": "#/$defs/helm-values.pdfEngines.engines" }
+      },
+      "additionalProperties": false
+    },
+    "helm-values.pdfEngines.disableRoutes": {
+      "description": "-- Disable the routes",
+      "type": "boolean",
+      "default": false
+    },
+    "helm-values.pdfEngines.engines": {
+      "description": "-- Set the PDF engines and their order - all by default",
+      "type": "string",
+      "default": ""
+    },
+    "helm-values.podAnnotations": { "type": "object", "default": {} },
+    "helm-values.podLabels": {
+      "description": "-- List of additional pod labels",
+      "type": "object",
+      "default": {}
+    },
+    "helm-values.podSecurityContext": { "type": "object", "default": {} },
+    "helm-values.progressDeadlineSeconds": { "type": "number", "default": 120 },
+    "helm-values.prometheus": {
+      "type": "object",
+      "properties": {
+        "collectInterval": {
+          "$ref": "#/$defs/helm-values.prometheus.collectInterval"
+        },
+        "disableCollect": {
+          "$ref": "#/$defs/helm-values.prometheus.disableCollect"
+        },
+        "disableRouterLogging": {
+          "$ref": "#/$defs/helm-values.prometheus.disableRouterLogging"
+        },
+        "namespace": { "$ref": "#/$defs/helm-values.prometheus.namespace" }
+      },
+      "additionalProperties": false
+    },
+    "helm-values.prometheus.collectInterval": {
+      "description": "-- Set the interval for collecting modules' metrics (default 1s)",
+      "type": "string",
+      "default": ""
+    },
+    "helm-values.prometheus.disableCollect": {
+      "description": "-- Disable the collect of metrics",
+      "type": "boolean",
+      "default": false
+    },
+    "helm-values.prometheus.disableRouterLogging": {
+      "description": "-- Disable the route logging",
+      "type": "boolean",
+      "default": false
+    },
+    "helm-values.prometheus.namespace": {
+      "description": "-- Set the namespace of modules' metrics (default \"gotenberg\")",
+      "type": "string",
+      "default": ""
+    },
+    "helm-values.replicaCount": { "type": "number", "default": 1 },
+    "helm-values.resources": { "type": "object", "default": {} },
+    "helm-values.securityContext": {
+      "description": "-- Define the security context for the container. By default will use upstream recommended values.\n@default -- `{ privileged: false, runAsUser: 1001 }`, except in OpenShift where `runAsUser` is not set.",
+      "type": "object",
+      "default": {}
+    },
+    "helm-values.service": {
+      "type": "object",
+      "properties": {
+        "annotations": { "$ref": "#/$defs/helm-values.service.annotations" },
+        "port": { "$ref": "#/$defs/helm-values.service.port" },
+        "type": { "$ref": "#/$defs/helm-values.service.type" }
+      },
+      "additionalProperties": false
+    },
+    "helm-values.service.annotations": {
+      "description": "-- Annotations to add to the service",
+      "type": "object",
+      "default": {}
+    },
+    "helm-values.service.port": { "type": "number", "default": 80 },
+    "helm-values.service.type": { "type": "string", "default": "ClusterIP" },
+    "helm-values.serviceAccount": {
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "$ref": "#/$defs/helm-values.serviceAccount.annotations"
+        },
+        "create": { "$ref": "#/$defs/helm-values.serviceAccount.create" },
+        "name": { "$ref": "#/$defs/helm-values.serviceAccount.name" }
+      },
+      "additionalProperties": false
+    },
+    "helm-values.serviceAccount.annotations": {
+      "description": "-- Annotations to add to the service account",
+      "type": "object",
+      "default": {}
+    },
+    "helm-values.serviceAccount.create": {
+      "description": "-- Specifies whether a service account should be created",
+      "type": "boolean",
+      "default": false
+    },
+    "helm-values.serviceAccount.name": {
+      "description": "-- The name of the service account to use.\nIf not set and create is true, a name is generated using the fullname template",
+      "type": "string",
+      "default": ""
+    },
+    "helm-values.strategy": {
+      "description": "Strategy is utilized to configure the desired upgrade approach and configuration for the deployment.",
+      "type": "object",
+      "default": {}
+    },
+    "helm-values.tolerations": { "type": "array", "default": [], "items": {} },
+    "helm-values.topologySpreadConstraints": {
+      "type": "array",
+      "default": [],
+      "items": {}
+    },
+    "helm-values.volumeMounts": { "type": "array", "default": [], "items": {} },
+    "helm-values.volumes": { "type": "array", "default": [], "items": {} },
+    "helm-values.webhook": {
+      "type": "object",
+      "properties": {
+        "allowList": { "$ref": "#/$defs/helm-values.webhook.allowList" },
+        "clientTimeout": {
+          "$ref": "#/$defs/helm-values.webhook.clientTimeout"
+        },
+        "denyList": { "$ref": "#/$defs/helm-values.webhook.denyList" },
+        "disable": { "$ref": "#/$defs/helm-values.webhook.disable" },
+        "errorAllowList": {
+          "$ref": "#/$defs/helm-values.webhook.errorAllowList"
+        },
+        "errorDenyList": {
+          "$ref": "#/$defs/helm-values.webhook.errorDenyList"
+        },
+        "maxRetry": { "$ref": "#/$defs/helm-values.webhook.maxRetry" },
+        "retryMaxWait": { "$ref": "#/$defs/helm-values.webhook.retryMaxWait" },
+        "retryMinWait": { "$ref": "#/$defs/helm-values.webhook.retryMinWait" }
+      },
+      "additionalProperties": false
+    },
+    "helm-values.webhook.allowList": {
+      "description": "-- Set the allowed URLs for the webhook feature using a regular expression",
+      "type": "string",
+      "default": ""
+    },
+    "helm-values.webhook.clientTimeout": {
+      "description": "-- Set the time limit for requests to the webhook (default 30s)",
+      "type": "string",
+      "default": ""
+    },
+    "helm-values.webhook.denyList": {
+      "description": "-- Set the denied URLs for the webhook feature using a regular expression",
+      "type": "string",
+      "default": ""
+    },
+    "helm-values.webhook.disable": {
+      "description": "-- Disable the webhook feature",
+      "type": "boolean",
+      "default": false
+    },
+    "helm-values.webhook.errorAllowList": {
+      "description": "-- Set the allowed URLs in case of an error for the webhook feature using a regular expression",
+      "type": "string",
+      "default": ""
+    },
+    "helm-values.webhook.errorDenyList": {
+      "description": "-- Set the denied URLs in case of an error for the webhook feature using a regular expression",
+      "type": "string",
+      "default": ""
+    },
+    "helm-values.webhook.maxRetry": {
+      "description": "-- Set the maximum number of retries for the webhook feature (default 4)",
+      "type": "string",
+      "default": ""
+    },
+    "helm-values.webhook.retryMaxWait": {
+      "description": "-- Set the maximum duration to wait before trying to call the webhook again (default 30s)",
+      "type": "string",
+      "default": ""
+    },
+    "helm-values.webhook.retryMinWait": {
+      "description": "-- Set the minimum duration to wait before trying to call the webhook again (default 1s)",
+      "type": "string",
+      "default": ""
+    }
+  }
+}

--- a/charts/gotenberg/values.schema.json
+++ b/charts/gotenberg/values.schema.json
@@ -5,50 +5,115 @@
     "helm-values": {
       "type": "object",
       "properties": {
-        "affinity": { "$ref": "#/$defs/helm-values.affinity" },
-        "api": { "$ref": "#/$defs/helm-values.api" },
-        "autoscaling": { "$ref": "#/$defs/helm-values.autoscaling" },
-        "chromium": { "$ref": "#/$defs/helm-values.chromium" },
-        "extraEnv": { "$ref": "#/$defs/helm-values.extraEnv" },
-        "fullnameOverride": { "$ref": "#/$defs/helm-values.fullnameOverride" },
-        "global": { "$ref": "#/$defs/helm-values.global" },
-        "gotenberg": { "$ref": "#/$defs/helm-values.gotenberg" },
-        "image": { "$ref": "#/$defs/helm-values.image" },
-        "imagePullSecrets": { "$ref": "#/$defs/helm-values.imagePullSecrets" },
-        "ingress": { "$ref": "#/$defs/helm-values.ingress" },
-        "libreOffice": { "$ref": "#/$defs/helm-values.libreOffice" },
-        "logging": { "$ref": "#/$defs/helm-values.logging" },
-        "metrics": { "$ref": "#/$defs/helm-values.metrics" },
-        "nameOverride": { "$ref": "#/$defs/helm-values.nameOverride" },
-        "nodeSelector": { "$ref": "#/$defs/helm-values.nodeSelector" },
-        "pdb": { "$ref": "#/$defs/helm-values.pdb" },
-        "pdfEngines": { "$ref": "#/$defs/helm-values.pdfEngines" },
-        "podAnnotations": { "$ref": "#/$defs/helm-values.podAnnotations" },
-        "podLabels": { "$ref": "#/$defs/helm-values.podLabels" },
+        "affinity": {
+          "$ref": "#/$defs/helm-values.affinity"
+        },
+        "api": {
+          "$ref": "#/$defs/helm-values.api"
+        },
+        "autoscaling": {
+          "$ref": "#/$defs/helm-values.autoscaling"
+        },
+        "chromium": {
+          "$ref": "#/$defs/helm-values.chromium"
+        },
+        "extraEnv": {
+          "$ref": "#/$defs/helm-values.extraEnv"
+        },
+        "fullnameOverride": {
+          "$ref": "#/$defs/helm-values.fullnameOverride"
+        },
+        "global": {
+          "$ref": "#/$defs/helm-values.global"
+        },
+        "gotenberg": {
+          "$ref": "#/$defs/helm-values.gotenberg"
+        },
+        "image": {
+          "$ref": "#/$defs/helm-values.image"
+        },
+        "imagePullSecrets": {
+          "$ref": "#/$defs/helm-values.imagePullSecrets"
+        },
+        "ingress": {
+          "$ref": "#/$defs/helm-values.ingress"
+        },
+        "libreOffice": {
+          "$ref": "#/$defs/helm-values.libreOffice"
+        },
+        "logging": {
+          "$ref": "#/$defs/helm-values.logging"
+        },
+        "metrics": {
+          "$ref": "#/$defs/helm-values.metrics"
+        },
+        "nameOverride": {
+          "$ref": "#/$defs/helm-values.nameOverride"
+        },
+        "nodeSelector": {
+          "$ref": "#/$defs/helm-values.nodeSelector"
+        },
+        "pdb": {
+          "$ref": "#/$defs/helm-values.pdb"
+        },
+        "pdfEngines": {
+          "$ref": "#/$defs/helm-values.pdfEngines"
+        },
+        "podAnnotations": {
+          "$ref": "#/$defs/helm-values.podAnnotations"
+        },
+        "podLabels": {
+          "$ref": "#/$defs/helm-values.podLabels"
+        },
         "podSecurityContext": {
           "$ref": "#/$defs/helm-values.podSecurityContext"
         },
         "progressDeadlineSeconds": {
           "$ref": "#/$defs/helm-values.progressDeadlineSeconds"
         },
-        "prometheus": { "$ref": "#/$defs/helm-values.prometheus" },
-        "replicaCount": { "$ref": "#/$defs/helm-values.replicaCount" },
-        "resources": { "$ref": "#/$defs/helm-values.resources" },
-        "securityContext": { "$ref": "#/$defs/helm-values.securityContext" },
-        "service": { "$ref": "#/$defs/helm-values.service" },
-        "serviceAccount": { "$ref": "#/$defs/helm-values.serviceAccount" },
-        "strategy": { "$ref": "#/$defs/helm-values.strategy" },
-        "tolerations": { "$ref": "#/$defs/helm-values.tolerations" },
+        "prometheus": {
+          "$ref": "#/$defs/helm-values.prometheus"
+        },
+        "replicaCount": {
+          "$ref": "#/$defs/helm-values.replicaCount"
+        },
+        "resources": {
+          "$ref": "#/$defs/helm-values.resources"
+        },
+        "securityContext": {
+          "$ref": "#/$defs/helm-values.securityContext"
+        },
+        "service": {
+          "$ref": "#/$defs/helm-values.service"
+        },
+        "serviceAccount": {
+          "$ref": "#/$defs/helm-values.serviceAccount"
+        },
+        "strategy": {
+          "$ref": "#/$defs/helm-values.strategy"
+        },
+        "tolerations": {
+          "$ref": "#/$defs/helm-values.tolerations"
+        },
         "topologySpreadConstraints": {
           "$ref": "#/$defs/helm-values.topologySpreadConstraints"
         },
-        "volumeMounts": { "$ref": "#/$defs/helm-values.volumeMounts" },
-        "volumes": { "$ref": "#/$defs/helm-values.volumes" },
-        "webhook": { "$ref": "#/$defs/helm-values.webhook" }
+        "volumeMounts": {
+          "$ref": "#/$defs/helm-values.volumeMounts"
+        },
+        "volumes": {
+          "$ref": "#/$defs/helm-values.volumes"
+        },
+        "webhook": {
+          "$ref": "#/$defs/helm-values.webhook"
+        }
       },
       "additionalProperties": false
     },
-    "helm-values.affinity": { "type": "object", "default": {} },
+    "helm-values.affinity": {
+      "type": "object",
+      "default": {}
+    },
     "helm-values.api": {
       "type": "object",
       "properties": {
@@ -76,11 +141,21 @@
         "enableBasicAuth": {
           "$ref": "#/$defs/helm-values.api.enableBasicAuth"
         },
-        "port": { "$ref": "#/$defs/helm-values.api.port" },
-        "rootPath": { "$ref": "#/$defs/helm-values.api.rootPath" },
-        "timeout": { "$ref": "#/$defs/helm-values.api.timeout" },
-        "tlsSecretName": { "$ref": "#/$defs/helm-values.api.tlsSecretName" },
-        "traceHeader": { "$ref": "#/$defs/helm-values.api.traceHeader" }
+        "port": {
+          "$ref": "#/$defs/helm-values.api.port"
+        },
+        "rootPath": {
+          "$ref": "#/$defs/helm-values.api.rootPath"
+        },
+        "timeout": {
+          "$ref": "#/$defs/helm-values.api.timeout"
+        },
+        "tlsSecretName": {
+          "$ref": "#/$defs/helm-values.api.tlsSecretName"
+        },
+        "traceHeader": {
+          "$ref": "#/$defs/helm-values.api.traceHeader"
+        }
       },
       "additionalProperties": false
     },
@@ -148,8 +223,12 @@
     "helm-values.autoscaling": {
       "type": "object",
       "properties": {
-        "behavior": { "$ref": "#/$defs/helm-values.autoscaling.behavior" },
-        "enabled": { "$ref": "#/$defs/helm-values.autoscaling.enabled" },
+        "behavior": {
+          "$ref": "#/$defs/helm-values.autoscaling.behavior"
+        },
+        "enabled": {
+          "$ref": "#/$defs/helm-values.autoscaling.enabled"
+        },
         "maxReplicas": {
           "$ref": "#/$defs/helm-values.autoscaling.maxReplicas"
         },
@@ -165,15 +244,29 @@
       },
       "additionalProperties": false
     },
-    "helm-values.autoscaling.behavior": { "type": "object", "default": {} },
-    "helm-values.autoscaling.enabled": { "type": "boolean", "default": false },
-    "helm-values.autoscaling.maxReplicas": { "type": "number", "default": 100 },
-    "helm-values.autoscaling.minReplicas": { "type": "number", "default": 1 },
+    "helm-values.autoscaling.behavior": {
+      "type": "object",
+      "default": {}
+    },
+    "helm-values.autoscaling.enabled": {
+      "type": "boolean",
+      "default": false
+    },
+    "helm-values.autoscaling.maxReplicas": {
+      "type": "number",
+      "default": 100
+    },
+    "helm-values.autoscaling.minReplicas": {
+      "type": "number",
+      "default": 1
+    },
     "helm-values.autoscaling.targetCPUUtilizationPercentage": {
       "type": "number",
       "default": 80
     },
-    "helm-values.autoscaling.targetMemoryUtilizationPercentage": {},
+    "helm-values.autoscaling.targetMemoryUtilizationPercentage": {
+      "type": "number"
+    },
     "helm-values.chromium": {
       "type": "object",
       "properties": {
@@ -183,11 +276,21 @@
         "allowInsecureLocalhost": {
           "$ref": "#/$defs/helm-values.chromium.allowInsecureLocalhost"
         },
-        "allowList": { "$ref": "#/$defs/helm-values.chromium.allowList" },
-        "autoStart": { "$ref": "#/$defs/helm-values.chromium.autoStart" },
-        "clearCache": { "$ref": "#/$defs/helm-values.chromium.clearCache" },
-        "clearCookies": { "$ref": "#/$defs/helm-values.chromium.clearCookies" },
-        "denyList": { "$ref": "#/$defs/helm-values.chromium.denyList" },
+        "allowList": {
+          "$ref": "#/$defs/helm-values.chromium.allowList"
+        },
+        "autoStart": {
+          "$ref": "#/$defs/helm-values.chromium.autoStart"
+        },
+        "clearCache": {
+          "$ref": "#/$defs/helm-values.chromium.clearCache"
+        },
+        "clearCookies": {
+          "$ref": "#/$defs/helm-values.chromium.clearCookies"
+        },
+        "denyList": {
+          "$ref": "#/$defs/helm-values.chromium.denyList"
+        },
         "disableJavaScript": {
           "$ref": "#/$defs/helm-values.chromium.disableJavaScript"
         },
@@ -203,11 +306,21 @@
         "ignoreCertificateErrors": {
           "$ref": "#/$defs/helm-values.chromium.ignoreCertificateErrors"
         },
-        "incognito": { "$ref": "#/$defs/helm-values.chromium.incognito" },
-        "maxQueueSize": { "$ref": "#/$defs/helm-values.chromium.maxQueueSize" },
-        "proxyServer": { "$ref": "#/$defs/helm-values.chromium.proxyServer" },
-        "restartAfter": { "$ref": "#/$defs/helm-values.chromium.restartAfter" },
-        "startTimeout": { "$ref": "#/$defs/helm-values.chromium.startTimeout" }
+        "incognito": {
+          "$ref": "#/$defs/helm-values.chromium.incognito"
+        },
+        "maxQueueSize": {
+          "$ref": "#/$defs/helm-values.chromium.maxQueueSize"
+        },
+        "proxyServer": {
+          "$ref": "#/$defs/helm-values.chromium.proxyServer"
+        },
+        "restartAfter": {
+          "$ref": "#/$defs/helm-values.chromium.restartAfter"
+        },
+        "startTimeout": {
+          "$ref": "#/$defs/helm-values.chromium.startTimeout"
+        }
       },
       "additionalProperties": false
     },
@@ -302,7 +415,10 @@
       "default": [],
       "items": {}
     },
-    "helm-values.fullnameOverride": { "type": "string", "default": "" },
+    "helm-values.fullnameOverride": {
+      "type": "string",
+      "default": ""
+    },
     "helm-values.global": {
       "description": "Global values shared across all (sub)charts"
     },
@@ -323,9 +439,15 @@
     "helm-values.image": {
       "type": "object",
       "properties": {
-        "pullPolicy": { "$ref": "#/$defs/helm-values.image.pullPolicy" },
-        "repository": { "$ref": "#/$defs/helm-values.image.repository" },
-        "tag": { "$ref": "#/$defs/helm-values.image.tag" }
+        "pullPolicy": {
+          "$ref": "#/$defs/helm-values.image.pullPolicy"
+        },
+        "repository": {
+          "$ref": "#/$defs/helm-values.image.repository"
+        },
+        "tag": {
+          "$ref": "#/$defs/helm-values.image.tag"
+        }
       },
       "additionalProperties": false
     },
@@ -350,11 +472,21 @@
     "helm-values.ingress": {
       "type": "object",
       "properties": {
-        "annotations": { "$ref": "#/$defs/helm-values.ingress.annotations" },
-        "className": { "$ref": "#/$defs/helm-values.ingress.className" },
-        "enabled": { "$ref": "#/$defs/helm-values.ingress.enabled" },
-        "hosts": { "$ref": "#/$defs/helm-values.ingress.hosts" },
-        "tls": { "$ref": "#/$defs/helm-values.ingress.tls" }
+        "annotations": {
+          "$ref": "#/$defs/helm-values.ingress.annotations"
+        },
+        "className": {
+          "$ref": "#/$defs/helm-values.ingress.className"
+        },
+        "enabled": {
+          "$ref": "#/$defs/helm-values.ingress.enabled"
+        },
+        "hosts": {
+          "$ref": "#/$defs/helm-values.ingress.hosts"
+        },
+        "tls": {
+          "$ref": "#/$defs/helm-values.ingress.tls"
+        }
       },
       "additionalProperties": false
     },
@@ -388,7 +520,9 @@
     "helm-values.libreOffice": {
       "type": "object",
       "properties": {
-        "autoStart": { "$ref": "#/$defs/helm-values.libreOffice.autoStart" },
+        "autoStart": {
+          "$ref": "#/$defs/helm-values.libreOffice.autoStart"
+        },
         "disableRoutes": {
           "$ref": "#/$defs/helm-values.libreOffice.disableRoutes"
         },
@@ -432,9 +566,15 @@
     "helm-values.logging": {
       "type": "object",
       "properties": {
-        "fieldsPrefix": { "$ref": "#/$defs/helm-values.logging.fieldsPrefix" },
-        "format": { "$ref": "#/$defs/helm-values.logging.format" },
-        "level": { "$ref": "#/$defs/helm-values.logging.level" }
+        "fieldsPrefix": {
+          "$ref": "#/$defs/helm-values.logging.fieldsPrefix"
+        },
+        "format": {
+          "$ref": "#/$defs/helm-values.logging.format"
+        },
+        "level": {
+          "$ref": "#/$defs/helm-values.logging.level"
+        }
       },
       "additionalProperties": false
     },
@@ -542,23 +682,44 @@
     "helm-values.metrics.serviceMonitor.scrapeTimeout": {
       "description": "-- (string) Timeout after which the scrape is ended"
     },
-    "helm-values.nameOverride": { "type": "string", "default": "" },
-    "helm-values.nodeSelector": { "type": "object", "default": {} },
+    "helm-values.nameOverride": {
+      "type": "string",
+      "default": ""
+    },
+    "helm-values.nodeSelector": {
+      "type": "object",
+      "default": {}
+    },
     "helm-values.pdb": {
       "type": "object",
       "properties": {
-        "create": { "$ref": "#/$defs/helm-values.pdb.create" },
-        "maxUnavailable": { "$ref": "#/$defs/helm-values.pdb.maxUnavailable" },
-        "minAvailable": { "$ref": "#/$defs/helm-values.pdb.minAvailable" },
+        "create": {
+          "$ref": "#/$defs/helm-values.pdb.create"
+        },
+        "maxUnavailable": {
+          "$ref": "#/$defs/helm-values.pdb.maxUnavailable"
+        },
+        "minAvailable": {
+          "$ref": "#/$defs/helm-values.pdb.minAvailable"
+        },
         "unhealthyPodEvictionPolicy": {
           "$ref": "#/$defs/helm-values.pdb.unhealthyPodEvictionPolicy"
         }
       },
       "additionalProperties": false
     },
-    "helm-values.pdb.create": { "type": "boolean", "default": false },
-    "helm-values.pdb.maxUnavailable": { "type": "string", "default": "" },
-    "helm-values.pdb.minAvailable": { "type": "number", "default": 1 },
+    "helm-values.pdb.create": {
+      "type": "boolean",
+      "default": false
+    },
+    "helm-values.pdb.maxUnavailable": {
+      "type": "string",
+      "default": ""
+    },
+    "helm-values.pdb.minAvailable": {
+      "type": "number",
+      "default": 1
+    },
     "helm-values.pdb.unhealthyPodEvictionPolicy": {
       "description": "-- This is a beta feature, so it's not enabled by default."
     },
@@ -568,7 +729,9 @@
         "disableRoutes": {
           "$ref": "#/$defs/helm-values.pdfEngines.disableRoutes"
         },
-        "engines": { "$ref": "#/$defs/helm-values.pdfEngines.engines" }
+        "engines": {
+          "$ref": "#/$defs/helm-values.pdfEngines.engines"
+        }
       },
       "additionalProperties": false
     },
@@ -582,14 +745,23 @@
       "type": "string",
       "default": ""
     },
-    "helm-values.podAnnotations": { "type": "object", "default": {} },
+    "helm-values.podAnnotations": {
+      "type": "object",
+      "default": {}
+    },
     "helm-values.podLabels": {
       "description": "-- List of additional pod labels",
       "type": "object",
       "default": {}
     },
-    "helm-values.podSecurityContext": { "type": "object", "default": {} },
-    "helm-values.progressDeadlineSeconds": { "type": "number", "default": 120 },
+    "helm-values.podSecurityContext": {
+      "type": "object",
+      "default": {}
+    },
+    "helm-values.progressDeadlineSeconds": {
+      "type": "number",
+      "default": 120
+    },
     "helm-values.prometheus": {
       "type": "object",
       "properties": {
@@ -602,7 +774,9 @@
         "disableRouterLogging": {
           "$ref": "#/$defs/helm-values.prometheus.disableRouterLogging"
         },
-        "namespace": { "$ref": "#/$defs/helm-values.prometheus.namespace" }
+        "namespace": {
+          "$ref": "#/$defs/helm-values.prometheus.namespace"
+        }
       },
       "additionalProperties": false
     },
@@ -626,8 +800,14 @@
       "type": "string",
       "default": ""
     },
-    "helm-values.replicaCount": { "type": "number", "default": 1 },
-    "helm-values.resources": { "type": "object", "default": {} },
+    "helm-values.replicaCount": {
+      "type": "number",
+      "default": 1
+    },
+    "helm-values.resources": {
+      "type": "object",
+      "default": {}
+    },
     "helm-values.securityContext": {
       "description": "-- Define the security context for the container. By default will use upstream recommended values.\n@default -- `{ privileged: false, runAsUser: 1001 }`, except in OpenShift where `runAsUser` is not set.",
       "type": "object",
@@ -636,9 +816,15 @@
     "helm-values.service": {
       "type": "object",
       "properties": {
-        "annotations": { "$ref": "#/$defs/helm-values.service.annotations" },
-        "port": { "$ref": "#/$defs/helm-values.service.port" },
-        "type": { "$ref": "#/$defs/helm-values.service.type" }
+        "annotations": {
+          "$ref": "#/$defs/helm-values.service.annotations"
+        },
+        "port": {
+          "$ref": "#/$defs/helm-values.service.port"
+        },
+        "type": {
+          "$ref": "#/$defs/helm-values.service.type"
+        }
       },
       "additionalProperties": false
     },
@@ -647,16 +833,26 @@
       "type": "object",
       "default": {}
     },
-    "helm-values.service.port": { "type": "number", "default": 80 },
-    "helm-values.service.type": { "type": "string", "default": "ClusterIP" },
+    "helm-values.service.port": {
+      "type": "number",
+      "default": 80
+    },
+    "helm-values.service.type": {
+      "type": "string",
+      "default": "ClusterIP"
+    },
     "helm-values.serviceAccount": {
       "type": "object",
       "properties": {
         "annotations": {
           "$ref": "#/$defs/helm-values.serviceAccount.annotations"
         },
-        "create": { "$ref": "#/$defs/helm-values.serviceAccount.create" },
-        "name": { "$ref": "#/$defs/helm-values.serviceAccount.name" }
+        "create": {
+          "$ref": "#/$defs/helm-values.serviceAccount.create"
+        },
+        "name": {
+          "$ref": "#/$defs/helm-values.serviceAccount.name"
+        }
       },
       "additionalProperties": false
     },
@@ -680,32 +876,56 @@
       "type": "object",
       "default": {}
     },
-    "helm-values.tolerations": { "type": "array", "default": [], "items": {} },
+    "helm-values.tolerations": {
+      "type": "array",
+      "default": [],
+      "items": {}
+    },
     "helm-values.topologySpreadConstraints": {
       "type": "array",
       "default": [],
       "items": {}
     },
-    "helm-values.volumeMounts": { "type": "array", "default": [], "items": {} },
-    "helm-values.volumes": { "type": "array", "default": [], "items": {} },
+    "helm-values.volumeMounts": {
+      "type": "array",
+      "default": [],
+      "items": {}
+    },
+    "helm-values.volumes": {
+      "type": "array",
+      "default": [],
+      "items": {}
+    },
     "helm-values.webhook": {
       "type": "object",
       "properties": {
-        "allowList": { "$ref": "#/$defs/helm-values.webhook.allowList" },
+        "allowList": {
+          "$ref": "#/$defs/helm-values.webhook.allowList"
+        },
         "clientTimeout": {
           "$ref": "#/$defs/helm-values.webhook.clientTimeout"
         },
-        "denyList": { "$ref": "#/$defs/helm-values.webhook.denyList" },
-        "disable": { "$ref": "#/$defs/helm-values.webhook.disable" },
+        "denyList": {
+          "$ref": "#/$defs/helm-values.webhook.denyList"
+        },
+        "disable": {
+          "$ref": "#/$defs/helm-values.webhook.disable"
+        },
         "errorAllowList": {
           "$ref": "#/$defs/helm-values.webhook.errorAllowList"
         },
         "errorDenyList": {
           "$ref": "#/$defs/helm-values.webhook.errorDenyList"
         },
-        "maxRetry": { "$ref": "#/$defs/helm-values.webhook.maxRetry" },
-        "retryMaxWait": { "$ref": "#/$defs/helm-values.webhook.retryMaxWait" },
-        "retryMinWait": { "$ref": "#/$defs/helm-values.webhook.retryMinWait" }
+        "maxRetry": {
+          "$ref": "#/$defs/helm-values.webhook.maxRetry"
+        },
+        "retryMaxWait": {
+          "$ref": "#/$defs/helm-values.webhook.retryMaxWait"
+        },
+        "retryMinWait": {
+          "$ref": "#/$defs/helm-values.webhook.retryMinWait"
+        }
       },
       "additionalProperties": false
     },

--- a/charts/gotenberg/values.yaml
+++ b/charts/gotenberg/values.yaml
@@ -67,6 +67,7 @@ autoscaling:
   maxReplicas: 100
   behavior: {}
   targetCPUUtilizationPercentage: 80
+  # +docs:property
   # targetMemoryUtilizationPercentage: 80
 
 pdb:


### PR DESCRIPTION
Helm tooling is all over the place. I'm adding experimental schema generation via[ helm-tool](https://github.com/cert-manager/helm-tool). In theory, we could also replace `helm-docs` with `helm-tool`, but that would require rewriting the comments. I'm not opposed to this, but let's get the schema working first.

There is also https://github.com/losisin/helm-values-schema-json which has some cool features like custom validation from comments, but I dislike the inline comment style and having to duplicate the description if we want to have both helm-docs and their schema generation.

The current implementation using `helm-tool` has the downside of descriptions in the schema being prefixed with `helm-docs` `--` prefix.

Other than that, I'm looking forward to `helm-tool` updates, and maybe we can switch to using just that for everything.

I'm going to keep this open for a bit for potential feedback or additional changes that could be pushed in the `1.8.0` release.

Tasks:

 - [x] I've made changes
 - [x] I've bumped chart's version in `Chart.yaml`
 - [x] I've added changes to charts `CHANGELOG.md`
 - [x] I've run [`helm-docs`](https://github.com/norwoodj/helm-docs)
