### PR TITLE
Add the ability to add `extraMetrics` for HPA

### DIFF
--- a/charts/gotenberg/CHANGELOG.md
+++ b/charts/gotenberg/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.10.0
+
+- Add ability to set `extraMetrics` for HPA ([@anthosz](https://github.com/anthosz))
+
 ## 1.9.1
 
 - Fixing 'Additional property enabled is not allowed' when using gotenberg in helm dependency (Thanks to Anthony | [@anthosz](https://github.com/anthosz))

--- a/charts/gotenberg/CHANGELOG.md
+++ b/charts/gotenberg/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.10.0
 
 - Add ability to set `extraMetrics` for HPA ([@anthosz](https://github.com/anthosz))
+- Bump `gotenberg` version `8.14.1` -> `8.15.3` ([@anthosz](https://github.com/anthosz))
 
 ## 1.9.1
 

--- a/charts/gotenberg/Chart.yaml
+++ b/charts/gotenberg/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.9.1"
+version: "1.10.0"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gotenberg/Chart.yaml
+++ b/charts/gotenberg/Chart.yaml
@@ -22,7 +22,7 @@ version: "1.10.0"
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "8.14.1"
+appVersion: "8.15.3"
 
 keywords:
   - gotenberg

--- a/charts/gotenberg/README.md
+++ b/charts/gotenberg/README.md
@@ -1,7 +1,7 @@
 # Gotenberg
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/gotenberg)](https://artifacthub.io/packages/helm/maikumori/gotenberg)
-![Version: 1.10.0](https://img.shields.io/badge/Version-1.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.14.1](https://img.shields.io/badge/AppVersion-8.14.1-informational?style=flat-square)
+![Version: 1.10.0](https://img.shields.io/badge/Version-1.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.15.3](https://img.shields.io/badge/AppVersion-8.15.3-informational?style=flat-square)
 
 This is a HELM chart for Gotenberg.
 

--- a/charts/gotenberg/README.md
+++ b/charts/gotenberg/README.md
@@ -1,7 +1,7 @@
 # Gotenberg
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/gotenberg)](https://artifacthub.io/packages/helm/maikumori/gotenberg)
-![Version: 1.9.1](https://img.shields.io/badge/Version-1.9.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.14.1](https://img.shields.io/badge/AppVersion-8.14.1-informational?style=flat-square)
+![Version: 1.10.0](https://img.shields.io/badge/Version-1.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.14.1](https://img.shields.io/badge/AppVersion-8.14.1-informational?style=flat-square)
 
 This is a HELM chart for Gotenberg.
 
@@ -64,6 +64,7 @@ helm upgrade my-release maikumori/gotenberg --install
 | api.traceHeader | string | `""` | Set the header name to use for identifying requests (default "Gotenberg-Trace") |
 | autoscaling.behavior | object | `{}` |  |
 | autoscaling.enabled | bool | `false` |  |
+| autoscaling.extraMetrics | list | `[]` |  |
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |

--- a/charts/gotenberg/templates/hpa.yaml
+++ b/charts/gotenberg/templates/hpa.yaml
@@ -31,4 +31,7 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
+    {{- with .Values.autoscaling.extraMetrics }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/charts/gotenberg/values.schema.json
+++ b/charts/gotenberg/values.schema.json
@@ -238,6 +238,9 @@
         "enabled": {
           "$ref": "#/$defs/helm-values.autoscaling.enabled"
         },
+        "extraMetrics": {
+          "$ref": "#/$defs/helm-values.autoscaling.extraMetrics"
+        },
         "maxReplicas": {
           "$ref": "#/$defs/helm-values.autoscaling.maxReplicas"
         },
@@ -260,6 +263,11 @@
     "helm-values.autoscaling.enabled": {
       "type": "boolean",
       "default": false
+    },
+    "helm-values.autoscaling.extraMetrics": {
+      "type": "array",
+      "default": [],
+      "items": {}
     },
     "helm-values.autoscaling.maxReplicas": {
       "type": "number",

--- a/charts/gotenberg/values.yaml
+++ b/charts/gotenberg/values.yaml
@@ -74,6 +74,7 @@ autoscaling:
   minReplicas: 1
   maxReplicas: 100
   behavior: {}
+  extraMetrics: []
   targetCPUUtilizationPercentage: 80
   # +docs:property
   # targetMemoryUtilizationPercentage: 80


### PR DESCRIPTION
In addition of cpu/memory basic metric, goal is to allow to scale the pods based on custom metrics (by example: the libreoffice/chromium queue metrics)

Tasks:

- [x] I've made changes
- [x] I've bumped chart's version in `Chart.yaml`
- [x] I've added changes to charts `CHANGELOG.md`
- [x] I've run [`helm-docs`](https://github.com/norwoodj/helm-docs)
- [x] I've run ['helm-tool schema | jq . > values.schema.json'](https://github.com/cert-manager/helm-tool)
