### PR TITLE
Add possibility to customize livenessProbe and readinessProbe for deployment

### DIFF
--- a/charts/gotenberg/CHANGELOG.md
+++ b/charts/gotenberg/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.10.1
+## 1.11.0
 
 - Add possibility to customize `livenessProbe` and `readinessProbe` for deployment ([@v-starodubov](https://github.com/v-starodubov))
 

--- a/charts/gotenberg/CHANGELOG.md
+++ b/charts/gotenberg/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.10.1
+
+- Add possibility to customize `livenessProbe` and `readinessProbe` for deployment ([@v-starodubov](https://github.com/v-starodubov))
+
 ## 1.10.0
 
 - Add ability to set `extraMetrics` for HPA ([@anthosz](https://github.com/anthosz))

--- a/charts/gotenberg/Chart.yaml
+++ b/charts/gotenberg/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.10.0"
+version: "1.10.1"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gotenberg/Chart.yaml
+++ b/charts/gotenberg/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.10.1"
+version: "1.11.0"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gotenberg/README.md
+++ b/charts/gotenberg/README.md
@@ -1,7 +1,7 @@
 # Gotenberg
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/gotenberg)](https://artifacthub.io/packages/helm/maikumori/gotenberg)
-![Version: 1.10.1](https://img.shields.io/badge/Version-1.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.15.3](https://img.shields.io/badge/AppVersion-8.15.3-informational?style=flat-square)
+![Version: 1.11.0](https://img.shields.io/badge/Version-1.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.15.3](https://img.shields.io/badge/AppVersion-8.15.3-informational?style=flat-square)
 
 This is a HELM chart for Gotenberg.
 

--- a/charts/gotenberg/README.md
+++ b/charts/gotenberg/README.md
@@ -102,7 +102,7 @@ helm upgrade my-release maikumori/gotenberg --install
 | libreOffice.maxQueueSize | int | `0` | Maximum request queue size for LibreOffice. Set to 0 to disable this feature. |
 | libreOffice.restartAfter | string | `""` | Number of conversions after which LibreOffice will automatically restart. Set to 0 to disable this feature (default 10) |
 | libreOffice.startTimeout | string | `""` | Maximum duration to wait for LibreOffice to start or restart (default 10s) |
-| livenessProbe | object | `{ httpGet: { path: /health, port: http } }` | Define the liveness probe object for for the container. By default will use upstream recommended values. |
+| livenessProbe | object | `{ httpGet: { path: /health, port: http } }` | Define the liveness probe object for the container. By default will use upstream recommended values. |
 | logging.fieldsPrefix | string | `""` | Prepend a specified prefix to each field in the logs |
 | logging.format | string | `""` | Set log format - auto, json, or text (default "auto") |
 | logging.level | string | `""` | Set the log level - error, warn, info, or debug (default "info") |
@@ -137,7 +137,7 @@ helm upgrade my-release maikumori/gotenberg --install
 | prometheus.disableCollect | bool | `false` | Disable the collect of metrics |
 | prometheus.disableRouterLogging | bool | `false` | Disable the route logging |
 | prometheus.namespace | string | `""` | Set the namespace of modules' metrics (default "gotenberg") |
-| readinessProbe | object | `{ httpGet: { path: /health, port: http } }` | Define the readiness probe object for for the container. By default will use upstream recommended values. |
+| readinessProbe | object | `{ httpGet: { path: /health, port: http } }` | Define the readiness probe object for the container. By default will use upstream recommended values. |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | securityContext | object | `{ privileged: false, runAsUser: 1001 }`, except in OpenShift where `runAsUser` is not set. | Define the security context for the container. By default will use upstream recommended values. |

--- a/charts/gotenberg/README.md
+++ b/charts/gotenberg/README.md
@@ -102,7 +102,7 @@ helm upgrade my-release maikumori/gotenberg --install
 | libreOffice.maxQueueSize | int | `0` | Maximum request queue size for LibreOffice. Set to 0 to disable this feature. |
 | libreOffice.restartAfter | string | `""` | Number of conversions after which LibreOffice will automatically restart. Set to 0 to disable this feature (default 10) |
 | libreOffice.startTimeout | string | `""` | Maximum duration to wait for LibreOffice to start or restart (default 10s) |
-| livenessProbe | object | `{ httpGet: { path: /health, port: http } }` | Define the liveness probe object for the container. By default will use upstream recommended values. |
+| livenessProbe | object | `{"httpGet":{"path":"/health","port":"http"}}` | Define the liveness probe object for the container. +docs:property livenessProbe: {} |
 | logging.fieldsPrefix | string | `""` | Prepend a specified prefix to each field in the logs |
 | logging.format | string | `""` | Set log format - auto, json, or text (default "auto") |
 | logging.level | string | `""` | Set the log level - error, warn, info, or debug (default "info") |
@@ -137,7 +137,7 @@ helm upgrade my-release maikumori/gotenberg --install
 | prometheus.disableCollect | bool | `false` | Disable the collect of metrics |
 | prometheus.disableRouterLogging | bool | `false` | Disable the route logging |
 | prometheus.namespace | string | `""` | Set the namespace of modules' metrics (default "gotenberg") |
-| readinessProbe | object | `{ httpGet: { path: /health, port: http } }` | Define the readiness probe object for the container. By default will use upstream recommended values. |
+| readinessProbe | object | `{"httpGet":{"path":"/health","port":"http"}}` | Define the readiness probe object for the container. +docs:property readinessProbe: {} |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | securityContext | object | `{ privileged: false, runAsUser: 1001 }`, except in OpenShift where `runAsUser` is not set. | Define the security context for the container. By default will use upstream recommended values. |

--- a/charts/gotenberg/README.md
+++ b/charts/gotenberg/README.md
@@ -1,7 +1,7 @@
 # Gotenberg
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/gotenberg)](https://artifacthub.io/packages/helm/maikumori/gotenberg)
-![Version: 1.10.0](https://img.shields.io/badge/Version-1.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.15.3](https://img.shields.io/badge/AppVersion-8.15.3-informational?style=flat-square)
+![Version: 1.10.1](https://img.shields.io/badge/Version-1.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.15.3](https://img.shields.io/badge/AppVersion-8.15.3-informational?style=flat-square)
 
 This is a HELM chart for Gotenberg.
 
@@ -102,6 +102,7 @@ helm upgrade my-release maikumori/gotenberg --install
 | libreOffice.maxQueueSize | int | `0` | Maximum request queue size for LibreOffice. Set to 0 to disable this feature. |
 | libreOffice.restartAfter | string | `""` | Number of conversions after which LibreOffice will automatically restart. Set to 0 to disable this feature (default 10) |
 | libreOffice.startTimeout | string | `""` | Maximum duration to wait for LibreOffice to start or restart (default 10s) |
+| livenessProbe | object | `{ httpGet: { path: /health, port: http } }` | Define the liveness probe object for for the container. By default will use upstream recommended values. |
 | logging.fieldsPrefix | string | `""` | Prepend a specified prefix to each field in the logs |
 | logging.format | string | `""` | Set log format - auto, json, or text (default "auto") |
 | logging.level | string | `""` | Set the log level - error, warn, info, or debug (default "info") |
@@ -136,6 +137,7 @@ helm upgrade my-release maikumori/gotenberg --install
 | prometheus.disableCollect | bool | `false` | Disable the collect of metrics |
 | prometheus.disableRouterLogging | bool | `false` | Disable the route logging |
 | prometheus.namespace | string | `""` | Set the namespace of modules' metrics (default "gotenberg") |
+| readinessProbe | object | `{ httpGet: { path: /health, port: http } }` | Define the readiness probe object for for the container. By default will use upstream recommended values. |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | securityContext | object | `{ privileged: false, runAsUser: 1001 }`, except in OpenShift where `runAsUser` is not set. | Define the security context for the container. By default will use upstream recommended values. |

--- a/charts/gotenberg/templates/_helpers.tpl
+++ b/charts/gotenberg/templates/_helpers.tpl
@@ -88,3 +88,33 @@ readOnlyRootFilesystem: false
 {{- end}}
 {{- end}}
 {{- end}}
+
+{{/*
+Create a liveness probe context
+
+If .Values.livenessProbe is set, use it. Otherwise, use the defaults.
+*/}}
+{{- define "gotenberg.livenessProbe" -}}
+{{- if .Values.livenessProbe }}
+{{- toYaml .Values.livenessProbe }}
+{{- else -}}
+httpGet:
+  path: /health
+  port: http
+{{- end -}}
+{{- end }}
+
+{{/*
+Create a readiness probe context
+
+If .Values.readinessProbe is set, use it. Otherwise, use the defaults.
+*/}}
+{{- define "gotenberg.readinessProbe" -}}
+{{- if .Values.readinessProbe }}
+{{- toYaml .Values.readinessProbe }}
+{{- else -}}
+httpGet:
+  path: /health
+  port: http
+{{- end -}}
+{{- end }}

--- a/charts/gotenberg/templates/_helpers.tpl
+++ b/charts/gotenberg/templates/_helpers.tpl
@@ -88,33 +88,3 @@ readOnlyRootFilesystem: false
 {{- end}}
 {{- end}}
 {{- end}}
-
-{{/*
-Create a liveness probe context
-
-If .Values.livenessProbe is set, use it. Otherwise, use the defaults.
-*/}}
-{{- define "gotenberg.livenessProbe" -}}
-{{- if .Values.livenessProbe }}
-{{- toYaml .Values.livenessProbe }}
-{{- else -}}
-httpGet:
-  path: /health
-  port: http
-{{- end -}}
-{{- end }}
-
-{{/*
-Create a readiness probe context
-
-If .Values.readinessProbe is set, use it. Otherwise, use the defaults.
-*/}}
-{{- define "gotenberg.readinessProbe" -}}
-{{- if .Values.readinessProbe }}
-{{- toYaml .Values.readinessProbe }}
-{{- else -}}
-httpGet:
-  path: /health
-  port: http
-{{- end -}}
-{{- end }}

--- a/charts/gotenberg/templates/deployment.yaml
+++ b/charts/gotenberg/templates/deployment.yaml
@@ -222,13 +222,9 @@ spec:
               containerPort: {{ .Values.api.port }}
               protocol: TCP
           livenessProbe:
-            httpGet:
-              path: /health
-              port: http
+            {{- include "gotenberg.livenessProbe" . | nindent 12 }}
           readinessProbe:
-            httpGet:
-              path: /health
-              port: http
+            {{- include "gotenberg.readinessProbe" . | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/gotenberg/templates/deployment.yaml
+++ b/charts/gotenberg/templates/deployment.yaml
@@ -222,9 +222,9 @@ spec:
               containerPort: {{ .Values.api.port }}
               protocol: TCP
           livenessProbe:
-            {{- include "gotenberg.livenessProbe" . | nindent 12 }}
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
-            {{- include "gotenberg.readinessProbe" . | nindent 12 }}
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/gotenberg/values.schema.json
+++ b/charts/gotenberg/values.schema.json
@@ -44,6 +44,9 @@
         "libreOffice": {
           "$ref": "#/$defs/helm-values.libreOffice"
         },
+        "livenessProbe": {
+          "$ref": "#/$defs/helm-values.livenessProbe"
+        },
         "logging": {
           "$ref": "#/$defs/helm-values.logging"
         },
@@ -79,6 +82,9 @@
         },
         "prometheus": {
           "$ref": "#/$defs/helm-values.prometheus"
+        },
+        "readinessProbe": {
+          "$ref": "#/$defs/helm-values.readinessProbe"
         },
         "replicaCount": {
           "$ref": "#/$defs/helm-values.replicaCount"
@@ -585,6 +591,11 @@
       "type": "string",
       "default": ""
     },
+    "helm-values.livenessProbe": {
+      "description": "-- Define the liveness probe object for for the container. By default will use upstream recommended values.\n@default -- `{ httpGet: { path: /health, port: http } }`",
+      "type": "object",
+      "default": {}
+    },
     "helm-values.logging": {
       "type": "object",
       "properties": {
@@ -868,6 +879,11 @@
       "description": "-- Set the namespace of modules' metrics (default \"gotenberg\")",
       "type": "string",
       "default": ""
+    },
+    "helm-values.readinessProbe": {
+      "description": "-- Define the readiness probe object for for the container. By default will use upstream recommended values.\n@default -- `{ httpGet: { path: /health, port: http } }`",
+      "type": "object",
+      "default": {}
     },
     "helm-values.replicaCount": {
       "type": "number",

--- a/charts/gotenberg/values.schema.json
+++ b/charts/gotenberg/values.schema.json
@@ -592,7 +592,7 @@
       "default": ""
     },
     "helm-values.livenessProbe": {
-      "description": "-- Define the liveness probe object for for the container. By default will use upstream recommended values.\n@default -- `{ httpGet: { path: /health, port: http } }`",
+      "description": "-- Define the liveness probe object for the container. By default will use upstream recommended values.\n@default -- `{ httpGet: { path: /health, port: http } }`",
       "type": "object",
       "default": {}
     },
@@ -881,7 +881,7 @@
       "default": ""
     },
     "helm-values.readinessProbe": {
-      "description": "-- Define the readiness probe object for for the container. By default will use upstream recommended values.\n@default -- `{ httpGet: { path: /health, port: http } }`",
+      "description": "-- Define the readiness probe object for the container. By default will use upstream recommended values.\n@default -- `{ httpGet: { path: /health, port: http } }`",
       "type": "object",
       "default": {}
     },

--- a/charts/gotenberg/values.schema.json
+++ b/charts/gotenberg/values.schema.json
@@ -592,9 +592,14 @@
       "default": ""
     },
     "helm-values.livenessProbe": {
-      "description": "-- Define the liveness probe object for the container. By default will use upstream recommended values.\n@default -- `{ httpGet: { path: /health, port: http } }`",
+      "description": "-- Define the liveness probe object for the container.\nlivenessProbe: {}",
       "type": "object",
-      "default": {}
+      "default": {
+        "httpGet": {
+          "path": "/health",
+          "port": "http"
+        }
+      }
     },
     "helm-values.logging": {
       "type": "object",
@@ -881,9 +886,14 @@
       "default": ""
     },
     "helm-values.readinessProbe": {
-      "description": "-- Define the readiness probe object for the container. By default will use upstream recommended values.\n@default -- `{ httpGet: { path: /health, port: http } }`",
+      "description": "-- Define the readiness probe object for the container.\nreadinessProbe: {}",
       "type": "object",
-      "default": {}
+      "default": {
+        "httpGet": {
+          "path": "/health",
+          "port": "http"
+        }
+      }
     },
     "helm-values.replicaCount": {
       "type": "number",

--- a/charts/gotenberg/values.yaml
+++ b/charts/gotenberg/values.yaml
@@ -69,13 +69,21 @@ resources:
   #   cpu: 100m
   #   memory: 128Mi
 
-# -- Define the liveness probe object for the container. By default will use upstream recommended values.
-# @default -- `{ httpGet: { path: /health, port: http } }`
-livenessProbe: {}
+# -- Define the liveness probe object for the container.
+# +docs:property
+# livenessProbe: {}
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
 
-# -- Define the readiness probe object for the container. By default will use upstream recommended values.
-# @default -- `{ httpGet: { path: /health, port: http } }`
-readinessProbe: {}
+# -- Define the readiness probe object for the container.
+# +docs:property
+# readinessProbe: {}
+readinessProbe:
+  httpGet:
+    path: /health
+    port: http
 
 autoscaling:
   enabled: false

--- a/charts/gotenberg/values.yaml
+++ b/charts/gotenberg/values.yaml
@@ -69,6 +69,14 @@ resources:
   #   cpu: 100m
   #   memory: 128Mi
 
+# -- Define the liveness probe object for for the container. By default will use upstream recommended values.
+# @default -- `{ httpGet: { path: /health, port: http } }`
+livenessProbe: {}
+
+# -- Define the readiness probe object for for the container. By default will use upstream recommended values.
+# @default -- `{ httpGet: { path: /health, port: http } }`
+readinessProbe: {}
+
 autoscaling:
   enabled: false
   minReplicas: 1

--- a/charts/gotenberg/values.yaml
+++ b/charts/gotenberg/values.yaml
@@ -69,11 +69,11 @@ resources:
   #   cpu: 100m
   #   memory: 128Mi
 
-# -- Define the liveness probe object for for the container. By default will use upstream recommended values.
+# -- Define the liveness probe object for the container. By default will use upstream recommended values.
 # @default -- `{ httpGet: { path: /health, port: http } }`
 livenessProbe: {}
 
-# -- Define the readiness probe object for for the container. By default will use upstream recommended values.
+# -- Define the readiness probe object for the container. By default will use upstream recommended values.
 # @default -- `{ httpGet: { path: /health, port: http } }`
 readinessProbe: {}
 


### PR DESCRIPTION
In some older versions of `gotenberg` provided health checks don't work (for example `thecodingmachine/gotenberg:6`), so it's good to have the ability to modify this.

Tasks:

- [x] I've made changes
- [x] I've bumped chart's version in `Chart.yaml`
- [x] I've added changes to charts `CHANGELOG.md`
- [x] I've run [`helm-docs`](https://github.com/norwoodj/helm-docs)
- [x] I've run ['helm-tool schema | jq . > values.schema.json'](https://github.com/cert-manager/helm-tool)
