### PR TITLE
fix: extraEnv values have incorrect indentation

### DIFF
--- a/charts/gotenberg/CHANGELOG.md
+++ b/charts/gotenberg/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.21.1
+
+- Fix incorrect indentation of `extraEnv` vars in `deployment.yaml`
+  (rendered at 10 spaces instead of 12, causing a YAML parse error).
+
 ## 1.21.0
 
 - Bump `gotenberg` version `8.31.0` -> `8.32.0`.

--- a/charts/gotenberg/Chart.yaml
+++ b/charts/gotenberg/Chart.yaml
@@ -4,7 +4,7 @@ icon: https://user-images.githubusercontent.com/8983173/130322857-185831e2-f041-
 description: A Helm chart for Gotenberg
 
 type: application
-version: "1.21.0"
+version: "1.21.1"
 appVersion: "8.32.0"
 
 keywords:

--- a/charts/gotenberg/templates/deployment.yaml
+++ b/charts/gotenberg/templates/deployment.yaml
@@ -363,7 +363,7 @@ spec:
               value: /home/gotenberg
           {{- end }}
           {{- with .Values.extraEnv }}
-          {{- toYaml . | nindent 10 }}
+          {{- toYaml . | nindent 12 }}
           {{- end }}
           ports:
             - name: http


### PR DESCRIPTION
Fixes the issues in https://github.com/MaikuMori/helm-charts/issues/97.

Tasks:

- [x] I've made changes
- [x] I've bumped chart's version in `Chart.yaml`
- [x] I've added changes to charts `CHANGELOG.md` and `Chart.yaml` (remove old version entries, add next version entries according to Artifact Hub's [changelog annotation](artifacthub.io/docs/topics/annotations/helm/))
- [x] I've run [`helm-docs`](https://github.com/norwoodj/helm-docs)
- [x] I've run ['helm-tool schema | jq . > values.schema.json'](https://github.com/cert-manager/helm-tool)
