### PR TITLE
Add `lifecycle` value for container lifecycle hooks

### DIFF
--- a/charts/gotenberg/CHANGELOG.md
+++ b/charts/gotenberg/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.23.0
+
+- Add `lifecycle` to set container lifecycle hooks, so a `preStop` hook can be configured. Without one, a pod removed by the HPA or by a rolling update drops connections that arrive in the ~1-2s window between the Service endpoint being removed and kube-proxy catching up. Gotenberg's graceful shutdown does not cover this case: `Api.Stop()` calls `srv.Shutdown()` as soon as there is no in-flight work and cancels the remainder of `--gotenberg-graceful-shutdown-duration`, so an idle pod closes its listener within milliseconds of SIGTERM. A `preStop` hook delays SIGTERM while the server keeps accepting, e.g. `lifecycle.preStop.exec.command: ["sh", "-c", "sleep 5"]`. In-flight requests were never affected — `srv.Shutdown()` drains those.
+
 ## 1.22.0
 
 - Bump `gotenberg` version `8.32.0` -> `8.34.0` (via `8.33.0`).

--- a/charts/gotenberg/CHANGELOG.md
+++ b/charts/gotenberg/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.23.0
 
-- Add `lifecycle` to set container lifecycle hooks, so a `preStop` hook can be configured. Without one, a pod removed by the HPA or by a rolling update drops connections that arrive in the ~1-2s window between the Service endpoint being removed and kube-proxy catching up. Gotenberg's graceful shutdown does not cover this case: `Api.Stop()` calls `srv.Shutdown()` as soon as there is no in-flight work and cancels the remainder of `--gotenberg-graceful-shutdown-duration`, so an idle pod closes its listener within milliseconds of SIGTERM. A `preStop` hook delays SIGTERM while the server keeps accepting, e.g. `lifecycle.preStop.exec.command: ["sh", "-c", "sleep 5"]`. In-flight requests were never affected — `srv.Shutdown()` drains those.
+- Add `lifecycle` to set container lifecycle hooks. A `preStop` hook (e.g. `preStop: {sleep: {seconds: 5}}`) prevents dropped connections during HPA scale-down and rolling updates: an idle Gotenberg closes its listener immediately on SIGTERM, before Service endpoint removal has propagated.
 
 ## 1.22.0
 

--- a/charts/gotenberg/Chart.yaml
+++ b/charts/gotenberg/Chart.yaml
@@ -4,7 +4,7 @@ icon: https://user-images.githubusercontent.com/8983173/130322857-185831e2-f041-
 description: A Helm chart for Gotenberg
 
 type: application
-version: "1.22.0"
+version: "1.23.0"
 appVersion: "8.34.0"
 
 keywords:

--- a/charts/gotenberg/Chart.yaml
+++ b/charts/gotenberg/Chart.yaml
@@ -34,21 +34,5 @@ annotations:
     - name: Chart's Changelog
       url: https://github.com/MaikuMori/helm-charts/blob/master/charts/gotenberg/CHANGELOG.md
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump Gotenberg version 8.32.0 to 8.34.0
-    - kind: fixed
-      description: "Fix incorrect indentation of extraEnv vars in deployment.yaml that caused a YAML parse error"
-    - kind: changed
-      description: "Breaking upstream change: LibreOffice now blocks content linked from untrusted locations (external http(s):// and local file:/// links no longer resolve during conversion). Unconditional upstream - no flag to disable. Embedded content is unaffected."
     - kind: added
-      description: Add logging.stdLevelCase (--log-std-level-case) to set the case of the level field in standard-output logs - lower (default) or upper
-    - kind: added
-      description: Add pdfEngines.facturXEngines (--pdfengines-factur-x-engines) for the new Factur-X / ZUGFeRD XMP metadata feature
-    - kind: added
-      description: Add pdfEngines.embedMetadataEngines (--pdfengines-embed-metadata-engines) for the embed-metadata feature (upstream flag that was previously missing from the chart)
-    - kind: fixed
-      description: "Upstream security fix: IsPublicIP now unwraps IPv4-mapped, 6to4, and Teredo IPv6 addresses and rejects embedded non-public IPv4, closing a denyPrivateIps bypass"
-    - kind: fixed
-      description: "Upstream security fix: caller-supplied output filenames now strip both / and \\ path separators"
-    - kind: fixed
-      description: "Upstream: ca-certificates installed in the chromium-only image, fixing outbound TLS failures in that variant"
+      description: Add lifecycle value to set container lifecycle hooks, e.g. a preStop hook to prevent dropped connections during HPA scale-down and rolling updates

--- a/charts/gotenberg/README.md
+++ b/charts/gotenberg/README.md
@@ -1,7 +1,7 @@
 # Gotenberg
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/gotenberg)](https://artifacthub.io/packages/helm/maikumori/gotenberg)
-![Version: 1.22.0](https://img.shields.io/badge/Version-1.22.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.34.0](https://img.shields.io/badge/AppVersion-8.34.0-informational?style=flat-square)
+![Version: 1.23.0](https://img.shields.io/badge/Version-1.23.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.34.0](https://img.shields.io/badge/AppVersion-8.34.0-informational?style=flat-square)
 
 This is a HELM chart for Gotenberg.
 

--- a/charts/gotenberg/README.md
+++ b/charts/gotenberg/README.md
@@ -158,6 +158,7 @@ This allows you to stay current with Gotenberg releases without waiting for a ne
 | libreOffice.maxQueueSize | int | `0` | Maximum request queue size for LibreOffice. Set to 0 to disable this feature. |
 | libreOffice.restartAfter | string | `""` | Number of conversions after which LibreOffice will automatically restart. Set to 0 to disable this feature (default 10) |
 | libreOffice.startTimeout | string | `""` | Maximum duration to wait for LibreOffice to start or restart (default 10s) |
+| lifecycle | object | `{}` | Define the container lifecycle hooks. A `preStop` hook keeps the server accepting connections while Service endpoints propagate on shutdown, which prevents dropped connections during scale-down and rolling updates. Gotenberg's own graceful shutdown does not cover this: it stops as soon as it is idle, so an idle pod closes its listener within milliseconds of SIGTERM. |
 | livenessProbe | object | `{"httpGet":{"path":"/health","port":"http"}}` | Define the liveness probe object for the container. +docs:property livenessProbe: {} |
 | logging.enableGcpFields | DEPRECATED | `false` | Enable GCP log field mapping for Cloud Run. Use stdEnableGcpFields instead. |
 | logging.enableGcpSeverity | bool | `false` | Enable GCP severity field mapping |

--- a/charts/gotenberg/templates/deployment.yaml
+++ b/charts/gotenberg/templates/deployment.yaml
@@ -388,6 +388,10 @@ spec:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if or .Values.volumeMounts .Values.api.tlsSecretName }}
           volumeMounts:
             {{- with .Values.volumeMounts }}

--- a/charts/gotenberg/values.schema.json
+++ b/charts/gotenberg/values.schema.json
@@ -50,6 +50,9 @@
         "libreOffice": {
           "$ref": "#/$defs/helm-values.libreOffice"
         },
+        "lifecycle": {
+          "$ref": "#/$defs/helm-values.lifecycle"
+        },
         "livenessProbe": {
           "$ref": "#/$defs/helm-values.livenessProbe"
         },
@@ -851,6 +854,11 @@
       "description": "-- Maximum duration to wait for LibreOffice to start or restart (default 10s)",
       "type": "string",
       "default": ""
+    },
+    "helm-values.lifecycle": {
+      "description": "-- Define the container lifecycle hooks. A `preStop` hook keeps the server accepting connections while Service endpoints propagate on shutdown, which prevents dropped connections during scale-down and rolling updates. Gotenberg's own graceful shutdown does not cover this: it stops as soon as it is idle, so an idle pod closes its listener within milliseconds of SIGTERM.",
+      "type": "object",
+      "default": {}
     },
     "helm-values.livenessProbe": {
       "description": "-- Define the liveness probe object for the container.\nlivenessProbe: {}",

--- a/charts/gotenberg/values.yaml
+++ b/charts/gotenberg/values.yaml
@@ -81,8 +81,8 @@ resources:
 # -- Define the container lifecycle hooks. A `preStop` hook keeps the server accepting connections while Service endpoints propagate on shutdown, which prevents dropped connections during scale-down and rolling updates. Gotenberg's own graceful shutdown does not cover this: it stops as soon as it is idle, so an idle pod closes its listener within milliseconds of SIGTERM.
 lifecycle: {}
 #  preStop:
-#    exec:
-#      command: ["sh", "-c", "sleep 5"]
+#    sleep:
+#      seconds: 5
 
 # -- Define the liveness probe object for the container.
 # +docs:property

--- a/charts/gotenberg/values.yaml
+++ b/charts/gotenberg/values.yaml
@@ -78,6 +78,12 @@ resources:
   #   cpu: 100m
   #   memory: 128Mi
 
+# -- Define the container lifecycle hooks. A `preStop` hook keeps the server accepting connections while Service endpoints propagate on shutdown, which prevents dropped connections during scale-down and rolling updates. Gotenberg's own graceful shutdown does not cover this: it stops as soon as it is idle, so an idle pod closes its listener within milliseconds of SIGTERM.
+lifecycle: {}
+#  preStop:
+#    exec:
+#      command: ["sh", "-c", "sleep 5"]
+
 # -- Define the liveness probe object for the container.
 # +docs:property
 # livenessProbe: {}


### PR DESCRIPTION
Adds an optional `lifecycle` value, passed through to the container, so a `preStop` hook can be configured.

Without one, a pod removed by the HPA or by a rolling update drops connections that arrive in the ~1–2s window between the Service endpoint being removed and kube-proxy catching up. Gotenberg's own graceful shutdown doesn't cover this: `Api.Stop()` calls `srv.Shutdown()` as soon as there's no in-flight work and returns `ErrCancelGracefulShutdownContext`, so an idle pod closes its listener within milliseconds of SIGTERM regardless of `--gotenberg-graceful-shutdown-duration`. Raising that duration doesn't help since it's only an upper bound.

A `preStop` hook fixes it because it runs *before* SIGTERM, so the server keeps accepting while endpoints propagate:

```yaml
lifecycle:
  preStop:
    exec:
      command: ["sh", "-c", "sleep 5"]
```

To be clear, in-flight requests were never affected — `srv.Shutdown()` drains those. This is only about new connections.

We hit this running the chart in production and reproduced it under load in a staging cluster: connect timeouts to Gotenberg lined up exactly with HPA scale-down events, and stopped once we patched a `preStop` hook in locally.

Chart version bumped to 1.23.0 and `CHANGELOG.md` updated per CONTRIBUTING.

One thing to check: I couldn't run `helm-tool` or `helm-docs` in my environment, so `values.schema.json` and the `README.md` values row are hand-written to match the generated format — `helm lint` passes and the schema keys are in the same alphabetical position the generator would use, but please regenerate to be sure. Happy to push a fixup if CI disagrees.
